### PR TITLE
implement as_uint8array

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -592,6 +592,10 @@ pub trait PdfiumLibraryBindings {
     #[cfg(target_arch = "wasm32")]
     fn FPDFBitmap_GetBuffer(&self, bitmap: FPDF_BITMAP) -> *const c_void;
 
+    #[allow(non_snake_case)]
+    #[cfg(target_arch = "wasm32")]
+    fn FPDFBitmap_GetBuffer_Uint8Array(&self, bitmap: FPDF_BITMAP) -> js_sys::Uint8Array;
+
     /// This function is not part of the Pdfium API. It is provided by `pdfium-render` as an
     /// alternative to directly mutating the data returned by
     /// [PdfiumLibraryBindings::FPDFBitmap_GetBuffer()].

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -195,6 +195,17 @@ impl<'a> PdfBitmap<'a> {
         unsafe { std::slice::from_raw_parts(buffer_start as *const u8, buffer_length as usize) }
     }
 
+    #[cfg(target_arch = "wasm32")]
+    pub fn as_uint8array(&mut self) -> js_sys::Uint8Array {
+        self.render();
+
+        let buffer_length = self.bindings.FPDFBitmap_GetStride(self.bitmap_handle)
+            * self.bindings.FPDFBitmap_GetHeight(self.bitmap_handle);
+
+        self.bindings
+            .FPDFBitmap_GetBuffer_Uint8Array(self.bitmap_handle)
+    }
+
     /// Returns a new Javascript `ImageData` object created from the bitmap buffer backing
     /// this [PdfBitmap], rendering the referenced page if necessary. The resulting ImageData
     /// can be easily displayed in an HTML <canvas> element like so:

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -199,9 +199,6 @@ impl<'a> PdfBitmap<'a> {
     pub fn as_uint8array(&mut self) -> js_sys::Uint8Array {
         self.render();
 
-        let buffer_length = self.bindings.FPDFBitmap_GetStride(self.bitmap_handle)
-            * self.bindings.FPDFBitmap_GetHeight(self.bitmap_handle);
-
         self.bindings
             .FPDFBitmap_GetBuffer_Uint8Array(self.bitmap_handle)
     }

--- a/src/thread_safe.rs
+++ b/src/thread_safe.rs
@@ -770,6 +770,13 @@ impl<T: PdfiumLibraryBindings> PdfiumLibraryBindings for ThreadSafePdfiumBinding
 
     #[inline]
     #[allow(non_snake_case)]
+    #[cfg(target_arch = "wasm32")]
+    fn FPDFBitmap_GetBuffer_Uint8Array(&self, bitmap: FPDF_BITMAP) -> js_sys::Uint8Array {
+        self.bindings.FPDFBitmap_GetBuffer_Uint8Array(bitmap)
+    }
+
+    #[inline]
+    #[allow(non_snake_case)]
     fn FPDFBitmap_SetBuffer(&self, bitmap: FPDF_BITMAP, buffer: &[u8]) -> bool {
         self.bindings.FPDFBitmap_SetBuffer(bitmap, buffer)
     }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -3251,6 +3251,34 @@ impl PdfiumLibraryBindings for WasmPdfiumBindings {
     }
 
     #[allow(non_snake_case)]
+    fn FPDFBitmap_GetBuffer_Uint8Array(&self, bitmap: FPDF_BITMAP) -> Uint8Array {
+        log::debug!("pdfium-render::PdfiumLibraryBindings::FPDFBitmap_GetBuffer_Uint8Array()");
+
+        let width = self.FPDFBitmap_GetWidth(bitmap);
+
+        let height = self.FPDFBitmap_GetHeight(bitmap);
+
+        let state = PdfiumRenderWasmState::lock();
+
+        let buffer_ptr = state
+            .call(
+                "FPDFBitmap_GetBuffer",
+                JsFunctionArgumentType::Pointer,
+                Some(vec![JsFunctionArgumentType::Pointer]),
+                Some(&JsValue::from(Array::of1(&Self::js_value_from_bitmap(
+                    bitmap,
+                )))),
+            )
+            .as_f64()
+            .unwrap() as u32;
+
+        let buffer_len = (width * height * PdfiumRenderWasmState::BYTES_PER_PIXEL) as u32;
+        state
+            .heap_u8()
+            .subarray(buffer_ptr, buffer_ptr + buffer_len)
+    }
+
+    #[allow(non_snake_case)]
     fn FPDFBitmap_SetBuffer(&self, bitmap: FPDF_BITMAP, buffer: &[u8]) -> bool {
         let buffer_length =
             (self.FPDFBitmap_GetStride(bitmap) * self.FPDFBitmap_GetHeight(bitmap)) as usize;


### PR DESCRIPTION
This PR implements `as_uint8array` on `PdfBitmap` when compiling to wasm.  
I would also advocate for removing `as_imagedata`, since it's a performance foorgun imho. It sadly cannot use `as_uint8array` since `web_sys::ImageData` can only be constructed using a `Vec` or `&[u8]`.