### PR TITLE
Fix for underflow bug when subtracting text span start from end

### DIFF
--- a/src/page_text.rs
+++ b/src/page_text.rs
@@ -128,7 +128,7 @@ impl<'a> PdfPageText<'a> {
             (Some(start), Some(end)) => Ok(PdfPageTextChars::new(
                 self,
                 start.index() as i32,
-                (end.index() - start.index() + 1) as i32,
+                end.index().saturating_sub(start.index()) as i32 + 1,
                 self.bindings,
             )),
             _ => Err(PdfiumError::NoCharsInRect),


### PR DESCRIPTION
https://github.com/ajrcarey/pdfium-render/issues/70

Thank you.