### PR TITLE
Use Rust's Path and PathBuf instead of String

### DIFF
--- a/src/pdfium.rs
+++ b/src/pdfium.rs
@@ -28,6 +28,7 @@ use std::io::{Read, Seek};
 
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::Path;
+use std::path::PathBuf;
 
 #[cfg(target_arch = "wasm32")]
 use crate::wasm::{PdfiumRenderWasmState, WasmPdfiumBindings};
@@ -128,11 +129,11 @@ impl Pdfium {
     #[cfg(not(feature = "static"))]
     #[inline]
     pub fn bind_to_library(
-        path: impl ToString,
+        path: impl AsRef<Path>,
     ) -> Result<Box<dyn PdfiumLibraryBindings>, PdfiumError> {
+        let path = path.as_ref();
         let bindings = DynamicPdfiumBindings::new(
-            unsafe { Library::new(OsString::from(path.to_string())) }
-                .map_err(PdfiumError::LoadLibraryError)?,
+            unsafe { Library::new(path.as_os_str()) }.map_err(PdfiumError::LoadLibraryError)?,
         )
         .map_err(PdfiumError::LoadLibraryError)?;
 
@@ -157,12 +158,10 @@ impl Pdfium {
     #[cfg(not(target_arch = "wasm32"))]
     #[cfg(not(feature = "static"))]
     #[inline]
-    pub fn pdfium_platform_library_name_at_path(path: impl ToString) -> String {
-        let mut path = path.to_string();
+    pub fn pdfium_platform_library_name_at_path(path: impl AsRef<Path>) -> PathBuf {
+        let path = path.as_ref();
 
-        path.push_str(Pdfium::pdfium_platform_library_name().to_str().unwrap());
-
-        path
+        path.join(Pdfium::pdfium_platform_library_name())
     }
 
     /// Creates a new [Pdfium] instance from the given external Pdfium library bindings.

--- a/src/pdfium.rs
+++ b/src/pdfium.rs
@@ -133,7 +133,7 @@ impl Pdfium {
     ) -> Result<Box<dyn PdfiumLibraryBindings>, PdfiumError> {
         let path = path.as_ref();
         let bindings = DynamicPdfiumBindings::new(
-            unsafe { Library::new(path.as_os_str()) }.map_err(PdfiumError::LoadLibraryError)?,
+            unsafe { Library::new(path) }.map_err(PdfiumError::LoadLibraryError)?,
         )
         .map_err(PdfiumError::LoadLibraryError)?;
 

--- a/src/pdfium.rs
+++ b/src/pdfium.rs
@@ -158,10 +158,23 @@ impl Pdfium {
     #[cfg(not(target_arch = "wasm32"))]
     #[cfg(not(feature = "static"))]
     #[inline]
-    pub fn pdfium_platform_library_name_at_path(path: impl AsRef<Path>) -> PathBuf {
+    pub fn pdfium_platform_library_name_at(path: impl AsRef<Path>) -> PathBuf {
         let path = path.as_ref();
 
         path.join(Pdfium::pdfium_platform_library_name())
+    }
+
+    /// Returns the name of the external Pdfium library on the currently running platform,
+    /// prefixed with the given path string.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(feature = "static"))]
+    #[inline]
+    pub fn pdfium_platform_library_name_at_path(path: impl ToString) -> String {
+        let mut path = path.to_string();
+
+        path.push_str(Pdfium::pdfium_platform_library_name().to_str().unwrap());
+
+        path
     }
 
     /// Creates a new [Pdfium] instance from the given external Pdfium library bindings.


### PR DESCRIPTION
Usually paths on the filesystem are represented using Path and PathBuf. Getting a String to pass to Pdfium::pdfium_platform_library_name_at_path is not straight forward.

This pull request adds two new functions 
1.  Pdfium::bind_to_library_at(path: impl AsRef<Path>)
2. Pdfium:: pdfium_platform_library_name_at(path: impl AsRef<Path>) 

to support this use case.

The existing functions are left unchanged. They could be replaced but that probably results in a breaking change 