### PR TITLE
[failing example] use a OnceCell - and we see failures in multi-threaded example (segfault)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ bindgen = { version = "^0" }
 # are specified separately in examples/Cargo.toml.
 rand = "^0" # Used by examples/create.rs, examples/matrix.rs
 rayon = "^1" # Used by examples/thread_safe.rs
+once_cell = "1.18.0"
 
 [features]
 default = ["image", "thread_safe"] # The image feature is implicit because the image dependency is optional.

--- a/examples/thread_safe.rs
+++ b/examples/thread_safe.rs
@@ -1,4 +1,5 @@
 use image::ImageFormat;
+use once_cell::sync::OnceCell;
 use pdfium_render::prelude::*;
 use rayon::prelude::*;
 use std::thread;
@@ -32,6 +33,14 @@ use std::thread;
 // application. To see an actual performance benefit, you _must_ use parallel processing,
 // _not_ multi-threading.
 
+fn pdfium() -> &'static Pdfium {
+    static INSTANCE: OnceCell<Pdfium> = OnceCell::new();
+
+    INSTANCE.get_or_init(|| {
+        Pdfium::new(Pdfium::bind_to_system_library().unwrap())
+    })
+}
+
 fn main() -> Result<(), PdfiumError> {
     // For general comments about pdfium-render and binding to Pdfium, see export.rs.
 
@@ -64,10 +73,12 @@ fn render(render_config: &PdfRenderConfig, path: &str) -> Result<(), PdfiumError
     // Render each page in the document at the given path out to a JPG file, using the
     // given bindings and rendering configuration.
 
-    let pdfium = Pdfium::new(
-        Pdfium::bind_to_library(Pdfium::pdfium_platform_library_name_at_path("./"))
-            .or_else(|_| Pdfium::bind_to_system_library())?,
-    );
+    // let pdfium = Pdfium::new(
+    //     Pdfium::bind_to_library(Pdfium::pdfium_platform_library_name_at_path("./"))
+    //         .or_else(|_| Pdfium::bind_to_system_library())?,
+    // );
+
+    let pdfium = pdfium();
 
     let document = pdfium.load_pdf_from_file(path, None)?;
 


### PR DESCRIPTION
I've been running into something similar in my usage of pdfium-render, and have attempted to reproduce via modifying the thread_safe example.

The readme alludes to it being ok, when using the sync feature, to initialize pdfium using something like a once_cell (I may have understood this part).

From reading the code though I don't see then how this would be protected - since the thread_safe feature seems to protect at bindings init time, but if you init once and then share around via sync feature there's nothing stopping concurrent access.

With this modified example I seem to reliably get segfaults when running this locally with
`cargo run --example thread_safe --features="thread_safe,sync"`

In my actual usecase (where I'm using some other features of pdfium, but seem to reliably hit with text extraction) I see a mixture of problems:
 - text extraction is incorrect - missing characters/garbled output
 - format errors when loading valid documents
 - unknown pdfium errors (PdfiumLibraryInternalError)
 - `../base/allocator/partition_allocator/partition_page.h(633) Check failed: entry != freelist_head`