### PR TITLE
add start index to PdfPageTextSegments

### DIFF
--- a/examples/text_search.rs
+++ b/examples/text_search.rs
@@ -1,0 +1,27 @@
+use pdfium_render::{page_text_search::SearchOption, prelude::*};
+
+pub fn main() -> Result<(), PdfiumError> {
+    let pdfium = Pdfium::new(
+        Pdfium::bind_to_library(Pdfium::pdfium_platform_library_name_at_path("./"))
+            .or_else(|_| Pdfium::bind_to_system_library())?,
+    );
+    let page = pdfium
+        .load_pdf_from_file("test/text-test.pdf", None)?
+        .pages()
+        .first()?;
+    let search_option = SearchOption {
+        match_case: false,
+        match_whole_world: false,
+        consecutive: false,
+    };
+    let page_text = page.text().unwrap();
+    let search = page_text.search("the", &search_option, 0);
+    search.iter(true).for_each(|segments| {
+        let index_range = segments.index_range();
+        println!("search result: {:?}", index_range.1 - index_range.0);
+        segments
+            .iter()
+            .for_each(|d| println!("segement: {:?}", d.text()));
+    });
+    Ok(())
+}

--- a/examples/text_segments.rs
+++ b/examples/text_segments.rs
@@ -1,0 +1,18 @@
+use pdfium_render::prelude::*;
+
+pub fn main() -> Result<(), PdfiumError> {
+    let pdfium = Pdfium::new(
+        Pdfium::bind_to_library(Pdfium::pdfium_platform_library_name_at_path("./"))
+            .or_else(|_| Pdfium::bind_to_system_library())?,
+    );
+    let page = pdfium
+        .load_pdf_from_file("test/text-test.pdf", None)?
+        .pages()
+        .first()?;
+    let page_text = page.text().unwrap();
+    let segments = page_text.select_segments(10, 300);
+    segments
+        .iter()
+        .for_each(|d| println!("segement: {:?}, {:?}", d.text(), d.bounds()));
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,7 @@ pub mod page_size;
 pub mod page_text;
 pub mod page_text_char;
 pub mod page_text_chars;
+pub mod page_text_search;
 pub mod page_text_segment;
 pub mod page_text_segments;
 pub mod pages;

--- a/src/page_text.rs
+++ b/src/page_text.rs
@@ -78,7 +78,13 @@ impl<'a> PdfPageText<'a> {
     /// Returns a collection of all the `PdfPageTextSegment` text segments in the containing [PdfPage].
     #[inline]
     pub fn segments(&self) -> PdfPageTextSegments {
-        PdfPageTextSegments::new(self, self.len(), self.bindings)
+        PdfPageTextSegments::new(self, 0, self.len(), self.bindings)
+    }
+
+    /// Returns a collection of all the `PdfPageTextSegment` text segments in the specified `start` index and char `count`.
+    #[inline]
+    pub fn select_segments(&self, start: i32, count: i32) -> PdfPageTextSegments {
+        PdfPageTextSegments::new(self, start, count, self.bindings)
     }
 
     /// Returns a collection of all the `PdfPageTextChar` characters in the containing [PdfPage].

--- a/src/page_text.rs
+++ b/src/page_text.rs
@@ -1,7 +1,7 @@
 //! Defines the [PdfPageText] struct, exposing functionality related to the
 //! collection of Unicode characters visible in a single `PdfPage`.
 
-use crate::bindgen::{FPDF_TEXTPAGE, FPDF_WCHAR};
+use crate::bindgen::{FPDF_TEXTPAGE, FPDF_WCHAR, FPDF_WIDESTRING};
 use crate::bindings::PdfiumLibraryBindings;
 use crate::page::PdfPage;
 use crate::page_annotation::PdfPageAnnotation;
@@ -10,11 +10,12 @@ use crate::page_object::PdfPageObjectCommon;
 use crate::page_object_private::internal::PdfPageObjectPrivate;
 use crate::page_object_text::PdfPageTextObject;
 use crate::page_text_chars::PdfPageTextChars;
+use crate::page_text_search::{SearchFlag, PageTextSearch, SearchOption};
 use crate::page_text_segments::PdfPageTextSegments;
 use crate::prelude::PdfiumError;
 use crate::rect::PdfRect;
 use crate::utils::mem::{create_byte_buffer, create_sized_buffer};
-use crate::utils::utf16le::get_string_from_pdfium_utf16le_bytes;
+use crate::utils::utf16le::{get_string_from_pdfium_utf16le_bytes, get_pdfium_utf16le_bytes_from_str};
 use bytemuck::cast_slice;
 use std::fmt::{Display, Formatter};
 use std::ptr::null_mut;
@@ -262,6 +263,19 @@ impl<'a> PdfPageText<'a> {
         let bounds = annotation.bounds()?;
 
         Ok(self.inside_rect(bounds))
+    }
+
+
+    /// Return [PageTextSearch]
+    pub fn search(&self, text: &str, search_option: &SearchOption, index: i32) -> PageTextSearch {
+
+        let handle = self.bindings.FPDFText_FindStart(
+            self.handle,
+            get_pdfium_utf16le_bytes_from_str(text).as_ptr() as FPDF_WIDESTRING,
+            search_option.as_pdfium(),
+            index,
+        );
+        PageTextSearch::from_pdfium(handle, self, self.bindings)
     }
 }
 

--- a/src/page_text_search.rs
+++ b/src/page_text_search.rs
@@ -1,0 +1,126 @@
+use crate::{
+    bindgen::FPDF_SCHHANDLE,
+    prelude::{PdfPageText, PdfPageTextSegments, PdfiumLibraryBindings},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+
+pub struct SearchOption {
+    pub match_case: bool,
+    pub match_whole_world: bool,
+    pub consecutive: bool,
+}
+
+impl SearchOption {
+    pub(crate) fn as_pdfium(&self) -> u64 {
+        // convert SearchOption to pdfium search flag
+        let mut flag = 0;
+        if self.match_case {
+            flag |= SearchFlag::MatchCase.as_pdfium();
+        }
+        if self.match_whole_world {
+            flag |= SearchFlag::MatchWholeWord.as_pdfium();
+        }
+        if self.consecutive {
+            flag |= SearchFlag::Consecutive.as_pdfium();
+        }
+        flag
+    }
+}
+pub(crate) enum SearchFlag {
+    MatchCase,
+    MatchWholeWord,
+    Consecutive,
+}
+impl SearchFlag {
+    #[inline]
+    pub(crate) fn as_pdfium(&self) -> u64 {
+        match self {
+            SearchFlag::MatchCase => 0x1,
+            SearchFlag::MatchWholeWord => 0x2,
+            SearchFlag::Consecutive => 0x4,
+        }
+    }
+}
+
+pub struct PageTextSearch<'a> {
+    handle: FPDF_SCHHANDLE,
+    text_page: &'a PdfPageText<'a>,
+    bindings: &'a dyn PdfiumLibraryBindings,
+}
+
+impl<'a> PageTextSearch<'a> {
+    pub(crate) fn from_pdfium(
+        handle: FPDF_SCHHANDLE,
+        text_page: &'a PdfPageText<'a>,
+        bindings: &'a dyn PdfiumLibraryBindings,
+    ) -> Self {
+        PageTextSearch {
+            handle,
+            text_page,
+            bindings,
+        }
+    }
+
+    #[inline]
+    pub fn bindings(&self) -> &'a dyn PdfiumLibraryBindings {
+        self.bindings
+    }
+
+    #[inline]
+    pub fn handle(&self) -> &FPDF_SCHHANDLE {
+        &self.handle
+    }
+
+    #[inline]
+    fn find_prev(&self) -> bool {
+        self.bindings.FPDFText_FindPrev(self.handle) != 0
+    }
+
+    #[inline]
+    fn find_next(&self) -> bool {
+        self.bindings.FPDFText_FindNext(self.handle) != 0
+    }
+
+    pub fn get_next_result(&self, search_forward: bool) -> Option<PdfPageTextSegments> {
+        let has_next = if search_forward {
+            self.find_next()
+        } else {
+            self.find_prev()
+        };
+        if has_next {
+            let start_index = self.bindings.FPDFText_GetSchResultIndex(self.handle);
+            let sch_count = self.bindings.FPDFText_GetSchCount(self.handle);
+
+            return Some(self.text_page.select_segments(start_index, sch_count));
+        } else {
+            None
+        }
+    }
+
+    pub fn iter(&self, search_forward: bool) -> PageTextSearchIterator {
+        PageTextSearchIterator::new(self, search_forward)
+    }
+}
+
+pub struct PageTextSearchIterator<'a> {
+    search: &'a PageTextSearch<'a>,
+    search_forward: bool,
+}
+
+impl<'a> PageTextSearchIterator<'a> {
+    pub(crate) fn new(search: &'a PageTextSearch<'a>, search_forward: bool) -> Self {
+        PageTextSearchIterator {
+            search,
+            search_forward,
+        }
+    }
+}
+
+impl<'a> Iterator for PageTextSearchIterator<'a> {
+    type Item = PdfPageTextSegments<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.search.get_next_result(self.search_forward)
+    }
+}

--- a/src/page_text_segments.rs
+++ b/src/page_text_segments.rs
@@ -13,6 +13,7 @@ pub type PdfPageTextSegmentIndex = usize;
 
 pub struct PdfPageTextSegments<'a> {
     text: &'a PdfPageText<'a>,
+    start: i32,
     characters: i32,
     bindings: &'a dyn PdfiumLibraryBindings,
 }
@@ -21,11 +22,13 @@ impl<'a> PdfPageTextSegments<'a> {
     #[inline]
     pub(crate) fn new(
         text: &'a PdfPageText<'a>,
+        start: i32,
         characters: i32,
         bindings: &'a dyn PdfiumLibraryBindings,
     ) -> Self {
         PdfPageTextSegments {
             text,
+            start,
             characters,
             bindings,
         }
@@ -41,7 +44,7 @@ impl<'a> PdfPageTextSegments<'a> {
     #[inline]
     pub fn len(&self) -> PdfPageTextSegmentIndex {
         self.bindings
-            .FPDFText_CountRects(*self.text.handle(), 0, self.characters) as usize
+            .FPDFText_CountRects(*self.text.handle(), self.start, self.characters) as usize
     }
 
     /// Returns `true` if this [PdfPageTextSegments] collection is empty.

--- a/src/page_text_segments.rs
+++ b/src/page_text_segments.rs
@@ -34,6 +34,11 @@ impl<'a> PdfPageTextSegments<'a> {
         }
     }
 
+    #[inline]
+    pub fn index_range(&self) -> (PdfPageTextSegmentIndex, PdfPageTextSegmentIndex) {
+        (self.start as usize, (self.start + self.characters) as usize)
+    }
+
     /// Returns the number of distinct rectangular areas occupied by text in the containing `PdfPage`.
     ///
     /// Pdfium automatically merges smaller text boxes into larger ones if all enclosed characters


### PR DESCRIPTION
As mentioned in issue #110 , add a `start` index to `PdfPageTextSegments` could make it applicable to more scenarios. An example is also added in `examples/text_segments.rs`.