### PR TITLE
Add `set_value()` on text fields

### DIFF
--- a/examples/form_fields.rs
+++ b/examples/form_fields.rs
@@ -26,11 +26,20 @@ pub fn main() -> Result<(), PdfiumError> {
     for (page_index, page) in pages.iter().enumerate() {
         let annotations = page.annotations();
 
-        for (annotation_index, annotation) in annotations.iter().enumerate() {
+        for (annotation_index, mut annotation) in annotations.iter().enumerate() {
             // The PdfPageAnnotation::as_form_field() helper function handles the filtering out
             // of non-form-field-wrapping annotations for us.
 
-            if let Some(field) = annotation.as_form_field() {
+            if let Some(field) = annotation.as_form_field_mut() {
+                // TODO: don't be hacky, move this to a separate code block, and save a copy of the pdf.
+                if let Some(text_field) = field.as_text_field_mut() {
+                    if text_field.name()
+                        == Some("form1[0].#subform[0].Pt1Line1b_GivenName[0]".to_string())
+                    {
+                        text_field.set_value("Pdfium Render")?;
+                    }
+                }
+
                 println!(
                     "Page {}, annotation {}: {:?}, {:?} has form field value: {}",
                     page_index,

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -20,6 +20,7 @@ use crate::document::PdfDocument;
 use crate::page::PdfPage;
 use crate::page_object::PdfPageObject;
 use crate::page_object_private::internal::PdfPageObjectPrivate;
+use crate::prelude::{PdfiumError, PdfiumInternalError};
 use crate::utils::pixels::{
     bgra_to_rgba, rgba_to_bgra, unaligned_bgr_to_rgba, unaligned_rgb_to_bgra,
 };
@@ -86,6 +87,24 @@ pub trait PdfiumLibraryBindings {
             self.TRUE()
         } else {
             self.FALSE()
+        }
+    }
+
+    /// Converts from a C-style boolean integer to a Rust `Result`
+    ///
+    /// This allows monadic chaining of operations that might fail, each step should return
+    /// `to_result()`. Meaning `Ok(())` on success and [PdfiumInternalError::Unknown] on failure.
+    ///
+    /// This behaviour is in accordance with [PdfiumInternalError], which describes how any function
+    /// encountering an error -- besides those related to loading -- will return a C-style boolean
+    /// integer to flag failure.
+    fn to_result(&self, bool: FPDF_BOOL) -> Result<(), PdfiumError> {
+        if self.is_true(bool) {
+            Ok(())
+        } else {
+            Err(
+                PdfiumError::PdfiumLibraryInternalError(PdfiumInternalError::Unknown)
+            )
         }
     }
 

--- a/src/form_field.rs
+++ b/src/form_field.rs
@@ -228,6 +228,15 @@ impl<'a> PdfFormField<'a> {
         }
     }
 
+    /// Returns a mutable reference to the underlying [PdfFormTextField] for this
+    /// [PdfFormField], if this form field has a field type of [PdfFormField::Text].
+    pub fn as_text_field_mut(&mut self) -> Option<&mut PdfFormTextField<'a>> {
+        match self {
+            PdfFormField::Text(field) => Some(field),
+            _ => None,
+        }
+    }
+
     /// Returns the underlying [PdfFormUnknownField] for this [PdfFormField],
     /// if this form field has a field type of [PdfFormField::Unknown].
     #[inline]

--- a/src/form_field_text.rs
+++ b/src/form_field_text.rs
@@ -4,6 +4,7 @@
 use crate::bindgen::{FPDF_ANNOTATION, FPDF_FORMHANDLE};
 use crate::bindings::PdfiumLibraryBindings;
 use crate::form_field_private::internal::PdfFormFieldPrivate;
+use crate::prelude::PdfiumError;
 
 /// A single `PdfFormField` of type `PdfFormFieldType::Text`. The form field object defines
 /// an interactive data entry widget that allows the user to enter data by typing.
@@ -42,6 +43,12 @@ impl<'a> PdfFormTextField<'a> {
     #[inline]
     pub fn value(&self) -> Option<String> {
         self.value_impl()
+    }
+
+    /// Sets the value of this [PdfFormTextField].
+    #[inline]
+    pub fn set_value(&mut self, value: &str) -> Result<(), PdfiumError> {
+        self.set_value_impl(value)
     }
 }
 


### PR DESCRIPTION
This is a draft PR for early feedback (from the _It Type Checks, So Push It_ dept.). It's a start on #132

Questions:

1. Is `to_result()` a good or bad idea? At first I used a chain of `if` statements to check the results of my `FPDF*` calls, but it was seriously confusing, which is how I found this abstraction.
2. The field update code is inside `PdfFormFieldPrivate`, when in #132 you (@ajrcarey) mentioned adding this functionality to the annotations code (and indeed, I see similar functions there, like `PdfPageAnnotationCommon::set_contents()`). I'm not sure how to do that _and_ reference the `set_value()` function from `PdfFormTextField` in an elegant/obvious way, so I'm wondering: am I approaching the problem in the wrong way? A bit of guidance here would be grand, thanks!

Next, I'm going to test whether this even works, add those `FORM*` bindings, and test whether they're even necessary.