### PR TITLE
Expose FPDF_GetPageSizeByIndexF and cache DynamicPdfiumBindings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -83,5 +83,9 @@ fn statically_link_pdfium() {
 
         #[cfg(feature = "libc++")]
         println!("cargo:rustc-link-lib=dylib=c++");
+    } else if let Ok(path) = std::env::var("PDFIUM_DYNAMIC_LIB_PATH") {
+        // Instruct cargo to dynamically link the given library during the build.
+        println!("cargo:rustc-link-lib=dylib=pdfium");
+        println!("cargo:rustc-link-search=native={}", path);
     }
 }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -14,7 +14,7 @@ use crate::bindgen::{
     FPDF_IMAGEOBJ_METADATA, FPDF_LINK, FPDF_OBJECT_TYPE, FPDF_PAGE, FPDF_PAGELINK, FPDF_PAGEOBJECT,
     FPDF_PAGEOBJECTMARK, FPDF_PAGERANGE, FPDF_PATHSEGMENT, FPDF_SCHHANDLE, FPDF_SIGNATURE,
     FPDF_STRUCTELEMENT, FPDF_STRUCTTREE, FPDF_TEXTPAGE, FPDF_TEXT_RENDERMODE, FPDF_WCHAR,
-    FPDF_WIDESTRING, FS_FLOAT, FS_MATRIX, FS_POINTF, FS_QUADPOINTSF, FS_RECTF,
+    FPDF_WIDESTRING, FS_FLOAT, FS_MATRIX, FS_POINTF, FS_QUADPOINTSF, FS_RECTF, FS_SIZEF,
 };
 use crate::document::PdfDocument;
 use crate::error::{PdfiumError, PdfiumInternalError};
@@ -490,6 +490,9 @@ pub trait PdfiumLibraryBindings {
 
     #[allow(non_snake_case)]
     fn FPDF_GetPageBoundingBox(&self, page: FPDF_PAGE, rect: *mut FS_RECTF) -> FPDF_BOOL;
+
+    #[allow(non_snake_case)]
+    fn FPDF_GetPageSizeByIndexF(&self, document: FPDF_DOCUMENT, page_index: c_int, size: *mut FS_SIZEF) -> FPDF_BOOL;
 
     #[allow(non_snake_case)]
     fn FPDFPage_GetMediaBox(

--- a/src/linked.rs
+++ b/src/linked.rs
@@ -6,7 +6,7 @@ use crate::bindgen::{
     FPDF_IMAGEOBJ_METADATA, FPDF_LINK, FPDF_OBJECT_TYPE, FPDF_PAGE, FPDF_PAGELINK, FPDF_PAGEOBJECT,
     FPDF_PAGEOBJECTMARK, FPDF_PAGERANGE, FPDF_PATHSEGMENT, FPDF_SCHHANDLE, FPDF_SIGNATURE,
     FPDF_STRUCTELEMENT, FPDF_STRUCTTREE, FPDF_TEXTPAGE, FPDF_TEXT_RENDERMODE, FPDF_WCHAR,
-    FPDF_WIDESTRING, FS_FLOAT, FS_MATRIX, FS_POINTF, FS_QUADPOINTSF, FS_RECTF,
+    FPDF_WIDESTRING, FS_FLOAT, FS_MATRIX, FS_POINTF, FS_QUADPOINTSF, FS_RECTF, FS_SIZEF,
 };
 use crate::bindings::PdfiumLibraryBindings;
 use std::ffi::CString;
@@ -526,6 +526,12 @@ impl PdfiumLibraryBindings for StaticPdfiumBindings {
     #[allow(non_snake_case)]
     fn FPDF_GetPageBoundingBox(&self, page: FPDF_PAGE, rect: *mut FS_RECTF) -> FPDF_BOOL {
         unsafe { crate::bindgen::FPDF_GetPageBoundingBox(page, rect) }
+    }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    fn FPDF_GetPageSizeByIndexF(&self, document: FPDF_DOCUMENT, page_index: c_int, size: *mut FS_SIZEF) -> FPDF_BOOL {
+        unsafe { crate::bindgen::FPDF_GetPageSizeByIndexF(document, page_index, size) }
     }
 
     #[inline]

--- a/src/native.rs
+++ b/src/native.rs
@@ -10,4816 +10,1575 @@ use crate::bindgen::{
     FS_MATRIX, FS_POINTF, FS_QUADPOINTSF, FS_RECTF, FS_SIZEF,
 };
 use crate::bindings::PdfiumLibraryBindings;
-use libloading::{Library, Symbol};
+use libloading::Library;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_double, c_float, c_int, c_uchar, c_uint, c_ulong, c_ushort, c_void};
 
+#[allow(non_snake_case)]
 pub(crate) struct DynamicPdfiumBindings {
-    library: Library,
+    _library: Library,
+    extern_FPDF_InitLibrary: unsafe extern "C" fn(),
+    extern_FPDF_DestroyLibrary: unsafe extern "C" fn(),
+    extern_FPDF_GetLastError: unsafe extern "C" fn() -> c_ulong,
+    extern_FPDF_CreateNewDocument: unsafe extern "C" fn() -> FPDF_DOCUMENT,
+    extern_FPDF_LoadDocument:
+        unsafe extern "C" fn(file_path: FPDF_STRING, password: FPDF_BYTESTRING) -> FPDF_DOCUMENT,
+    extern_FPDF_LoadMemDocument64: unsafe extern "C" fn(
+        data_buf: *const c_void,
+        size: c_ulong,
+        password: FPDF_BYTESTRING,
+    ) -> FPDF_DOCUMENT,
+    extern_FPDF_LoadCustomDocument: unsafe extern "C" fn(
+        pFileAccess: *mut FPDF_FILEACCESS,
+        password: FPDF_BYTESTRING,
+    ) -> FPDF_DOCUMENT,
+    extern_FPDF_SaveAsCopy: unsafe extern "C" fn(
+        document: FPDF_DOCUMENT,
+        pFileWrite: *mut FPDF_FILEWRITE,
+        flags: FPDF_DWORD,
+    ) -> FPDF_BOOL,
+    extern_FPDF_SaveWithVersion: unsafe extern "C" fn(
+        document: FPDF_DOCUMENT,
+        pFileWrite: *mut FPDF_FILEWRITE,
+        flags: FPDF_DWORD,
+        fileVersion: c_int,
+    ) -> FPDF_BOOL,
+    extern_FPDF_CloseDocument: unsafe extern "C" fn(document: FPDF_DOCUMENT),
+    extern_FPDF_DeviceToPage: unsafe extern "C" fn(
+        page: FPDF_PAGE,
+        start_x: c_int,
+        start_y: c_int,
+        size_x: c_int,
+        size_y: c_int,
+        rotate: c_int,
+        device_x: c_int,
+        device_y: c_int,
+        page_x: *mut c_double,
+        page_y: *mut c_double,
+    ) -> FPDF_BOOL,
+    extern_FPDF_PageToDevice: unsafe extern "C" fn(
+        page: FPDF_PAGE,
+        start_x: c_int,
+        start_y: c_int,
+        size_x: c_int,
+        size_y: c_int,
+        rotate: c_int,
+        page_x: c_double,
+        page_y: c_double,
+        device_x: *mut c_int,
+        device_y: *mut c_int,
+    ) -> FPDF_BOOL,
+    extern_FPDF_GetFileVersion:
+        unsafe extern "C" fn(doc: FPDF_DOCUMENT, fileVersion: *mut c_int) -> FPDF_BOOL,
+    extern_FPDF_GetFileIdentifier: unsafe extern "C" fn(
+        document: FPDF_DOCUMENT,
+        id_type: FPDF_FILEIDTYPE,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDF_GetMetaText: unsafe extern "C" fn(
+        document: FPDF_DOCUMENT,
+        tag: FPDF_BYTESTRING,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDF_GetDocPermissions: unsafe extern "C" fn(document: FPDF_DOCUMENT) -> c_ulong,
+    extern_FPDF_GetSecurityHandlerRevision: unsafe extern "C" fn(document: FPDF_DOCUMENT) -> c_int,
+    extern_FPDF_GetPageCount: unsafe extern "C" fn(document: FPDF_DOCUMENT) -> c_int,
+    extern_FPDF_LoadPage:
+        unsafe extern "C" fn(document: FPDF_DOCUMENT, page_index: c_int) -> FPDF_PAGE,
+    extern_FPDF_ClosePage: unsafe extern "C" fn(page: FPDF_PAGE),
+    extern_FPDF_ImportPagesByIndex: unsafe extern "C" fn(
+        dest_doc: FPDF_DOCUMENT,
+        src_doc: FPDF_DOCUMENT,
+        page_indices: *const c_int,
+        length: c_ulong,
+        index: c_int,
+    ) -> FPDF_BOOL,
+    extern_FPDF_ImportPages: unsafe extern "C" fn(
+        dest_doc: FPDF_DOCUMENT,
+        src_doc: FPDF_DOCUMENT,
+        pagerange: FPDF_BYTESTRING,
+        index: c_int,
+    ) -> FPDF_BOOL,
+    extern_FPDF_ImportNPagesToOne: unsafe extern "C" fn(
+        src_doc: FPDF_DOCUMENT,
+        output_width: c_float,
+        output_height: c_float,
+        num_pages_on_x_axis: size_t,
+        num_pages_on_y_axis: size_t,
+    ) -> FPDF_DOCUMENT,
+    extern_FPDF_GetPageLabel: unsafe extern "C" fn(
+        document: FPDF_DOCUMENT,
+        page_index: c_int,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDF_GetPageBoundingBox:
+        unsafe extern "C" fn(page: FPDF_PAGE, rect: *mut FS_RECTF) -> FPDF_BOOL,
+    extern_FPDF_GetPageSizeByIndexF: unsafe extern "C" fn(
+        page: FPDF_DOCUMENT,
+        page_index: c_int,
+        size: *mut FS_SIZEF,
+    ) -> FPDF_BOOL,
+    extern_FPDF_GetPageWidthF: unsafe extern "C" fn(page: FPDF_PAGE) -> c_float,
+    extern_FPDF_GetPageHeightF: unsafe extern "C" fn(page: FPDF_PAGE) -> c_float,
+    extern_FPDFText_GetCharIndexFromTextIndex:
+        unsafe extern "C" fn(text_page: FPDF_TEXTPAGE, nTextIndex: c_int) -> c_int,
+    extern_FPDFText_GetTextIndexFromCharIndex:
+        unsafe extern "C" fn(text_page: FPDF_TEXTPAGE, nCharIndex: c_int) -> c_int,
+    extern_FPDF_GetSignatureCount: unsafe extern "C" fn(document: FPDF_DOCUMENT) -> c_int,
+    extern_FPDF_GetSignatureObject:
+        unsafe extern "C" fn(document: FPDF_DOCUMENT, index: c_int) -> FPDF_SIGNATURE,
+    extern_FPDFSignatureObj_GetContents: unsafe extern "C" fn(
+        signature: FPDF_SIGNATURE,
+        buffer: *mut c_void,
+        length: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFSignatureObj_GetByteRange: unsafe extern "C" fn(
+        signature: FPDF_SIGNATURE,
+        buffer: *mut c_int,
+        length: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFSignatureObj_GetSubFilter: unsafe extern "C" fn(
+        signature: FPDF_SIGNATURE,
+        buffer: *mut c_char,
+        length: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFSignatureObj_GetReason: unsafe extern "C" fn(
+        signature: FPDF_SIGNATURE,
+        buffer: *mut c_void,
+        length: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFSignatureObj_GetTime: unsafe extern "C" fn(
+        signature: FPDF_SIGNATURE,
+        buffer: *mut c_char,
+        length: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFSignatureObj_GetDocMDPPermission:
+        unsafe extern "C" fn(signature: FPDF_SIGNATURE) -> c_uint,
+    extern_FPDF_StructTree_GetForPage: unsafe extern "C" fn(page: FPDF_PAGE) -> FPDF_STRUCTTREE,
+    extern_FPDF_StructTree_Close: unsafe extern "C" fn(struct_tree: FPDF_STRUCTTREE),
+    extern_FPDF_StructTree_CountChildren:
+        unsafe extern "C" fn(struct_tree: FPDF_STRUCTTREE) -> c_int,
+    extern_FPDF_StructTree_GetChildAtIndex:
+        unsafe extern "C" fn(struct_tree: FPDF_STRUCTTREE, index: c_int) -> FPDF_STRUCTELEMENT,
+    extern_FPDF_StructElement_GetAltText: unsafe extern "C" fn(
+        struct_element: FPDF_STRUCTELEMENT,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDF_StructElement_GetID: unsafe extern "C" fn(
+        struct_element: FPDF_STRUCTELEMENT,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDF_StructElement_GetLang: unsafe extern "C" fn(
+        struct_element: FPDF_STRUCTELEMENT,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDF_StructElement_GetStringAttribute: unsafe extern "C" fn(
+        struct_element: FPDF_STRUCTELEMENT,
+        attr_name: FPDF_BYTESTRING,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDF_StructElement_GetMarkedContentID:
+        unsafe extern "C" fn(struct_element: FPDF_STRUCTELEMENT) -> c_int,
+    extern_FPDF_StructElement_GetType: unsafe extern "C" fn(
+        struct_element: FPDF_STRUCTELEMENT,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDF_StructElement_GetTitle: unsafe extern "C" fn(
+        struct_element: FPDF_STRUCTELEMENT,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDF_StructElement_CountChildren:
+        unsafe extern "C" fn(struct_element: FPDF_STRUCTELEMENT) -> c_int,
+    extern_FPDF_StructElement_GetChildAtIndex: unsafe extern "C" fn(
+        struct_element: FPDF_STRUCTELEMENT,
+        index: c_int,
+    ) -> FPDF_STRUCTELEMENT,
+    extern_FPDFPage_New: unsafe extern "C" fn(
+        document: FPDF_DOCUMENT,
+        page_index: c_int,
+        width: c_double,
+        height: c_double,
+    ) -> FPDF_PAGE,
+    extern_FPDFPage_Delete: unsafe extern "C" fn(document: FPDF_DOCUMENT, page_index: c_int),
+    extern_FPDFPage_GetRotation: unsafe extern "C" fn(page: FPDF_PAGE) -> c_int,
+    extern_FPDFPage_SetRotation: unsafe extern "C" fn(page: FPDF_PAGE, rotate: c_int),
+    extern_FPDFPage_GetMediaBox: unsafe extern "C" fn(
+        page: FPDF_PAGE,
+        left: *mut c_float,
+        bottom: *mut c_float,
+        right: *mut c_float,
+        top: *mut c_float,
+    ) -> FPDF_BOOL,
+    extern_FPDFPage_GetCropBox: unsafe extern "C" fn(
+        page: FPDF_PAGE,
+        left: *mut c_float,
+        bottom: *mut c_float,
+        right: *mut c_float,
+        top: *mut c_float,
+    ) -> FPDF_BOOL,
+    extern_FPDFPage_GetBleedBox: unsafe extern "C" fn(
+        page: FPDF_PAGE,
+        left: *mut c_float,
+        bottom: *mut c_float,
+        right: *mut c_float,
+        top: *mut c_float,
+    ) -> FPDF_BOOL,
+    extern_FPDFPage_GetTrimBox: unsafe extern "C" fn(
+        page: FPDF_PAGE,
+        left: *mut c_float,
+        bottom: *mut c_float,
+        right: *mut c_float,
+        top: *mut c_float,
+    ) -> FPDF_BOOL,
+    extern_FPDFPage_GetArtBox: unsafe extern "C" fn(
+        page: FPDF_PAGE,
+        left: *mut c_float,
+        bottom: *mut c_float,
+        right: *mut c_float,
+        top: *mut c_float,
+    ) -> FPDF_BOOL,
+    extern_FPDFPage_SetMediaBox: unsafe extern "C" fn(
+        page: FPDF_PAGE,
+        left: c_float,
+        bottom: c_float,
+        right: c_float,
+        top: c_float,
+    ),
+    extern_FPDFPage_SetCropBox: unsafe extern "C" fn(
+        page: FPDF_PAGE,
+        left: c_float,
+        bottom: c_float,
+        right: c_float,
+        top: c_float,
+    ),
+    extern_FPDFPage_SetBleedBox: unsafe extern "C" fn(
+        page: FPDF_PAGE,
+        left: c_float,
+        bottom: c_float,
+        right: c_float,
+        top: c_float,
+    ),
+    extern_FPDFPage_SetTrimBox: unsafe extern "C" fn(
+        page: FPDF_PAGE,
+        left: c_float,
+        bottom: c_float,
+        right: c_float,
+        top: c_float,
+    ),
+    extern_FPDFPage_SetArtBox: unsafe extern "C" fn(
+        page: FPDF_PAGE,
+        left: c_float,
+        bottom: c_float,
+        right: c_float,
+        top: c_float,
+    ),
+    extern_FPDFPage_TransFormWithClip: unsafe extern "C" fn(
+        page: FPDF_PAGE,
+        matrix: *const FS_MATRIX,
+        clipRect: *const FS_RECTF,
+    ) -> FPDF_BOOL,
+    extern_FPDFPageObj_TransformClipPath: unsafe extern "C" fn(
+        page_object: FPDF_PAGEOBJECT,
+        a: f64,
+        b: f64,
+        c: f64,
+        d: f64,
+        e: f64,
+        f: f64,
+    ),
+    extern_FPDFPageObj_GetClipPath:
+        unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT) -> FPDF_CLIPPATH,
+    extern_FPDFClipPath_CountPaths: unsafe extern "C" fn(clip_path: FPDF_CLIPPATH) -> c_int,
+    extern_FPDFClipPath_CountPathSegments:
+        unsafe extern "C" fn(clip_path: FPDF_CLIPPATH, path_index: c_int) -> c_int,
+    extern_FPDFClipPath_GetPathSegment: unsafe extern "C" fn(
+        clip_path: FPDF_CLIPPATH,
+        path_index: c_int,
+        segment_index: c_int,
+    ) -> FPDF_PATHSEGMENT,
+    extern_FPDF_CreateClipPath:
+        unsafe extern "C" fn(left: f32, bottom: f32, right: f32, top: f32) -> FPDF_CLIPPATH,
+    extern_FPDF_DestroyClipPath: unsafe extern "C" fn(clipPath: FPDF_CLIPPATH),
+    extern_FPDFPage_InsertClipPath: unsafe extern "C" fn(page: FPDF_PAGE, clipPath: FPDF_CLIPPATH),
+    extern_FPDFPage_HasTransparency: unsafe extern "C" fn(page: FPDF_PAGE) -> FPDF_BOOL,
+    extern_FPDFPage_GenerateContent: unsafe extern "C" fn(page: FPDF_PAGE) -> FPDF_BOOL,
+    extern_FPDFBitmap_CreateEx: unsafe extern "C" fn(
+        width: c_int,
+        height: c_int,
+        format: c_int,
+        first_scan: *mut c_void,
+        stride: c_int,
+    ) -> FPDF_BITMAP,
+    extern_FPDFBitmap_Destroy: unsafe extern "C" fn(bitmap: FPDF_BITMAP),
+    extern_FPDFBitmap_GetFormat: unsafe extern "C" fn(bitmap: FPDF_BITMAP) -> c_int,
+    extern_FPDFBitmap_FillRect: unsafe extern "C" fn(
+        bitmap: FPDF_BITMAP,
+        left: c_int,
+        top: c_int,
+        width: c_int,
+        height: c_int,
+        color: FPDF_DWORD,
+    ),
+    extern_FPDFBitmap_GetBuffer: unsafe extern "C" fn(bitmap: FPDF_BITMAP) -> *mut c_void,
+    extern_FPDFBitmap_GetWidth: unsafe extern "C" fn(bitmap: FPDF_BITMAP) -> c_int,
+    extern_FPDFBitmap_GetHeight: unsafe extern "C" fn(bitmap: FPDF_BITMAP) -> c_int,
+    extern_FPDFBitmap_GetStride: unsafe extern "C" fn(bitmap: FPDF_BITMAP) -> c_int,
+    extern_FPDF_RenderPageBitmap: unsafe extern "C" fn(
+        bitmap: FPDF_BITMAP,
+        page: FPDF_PAGE,
+        start_x: c_int,
+        start_y: c_int,
+        size_x: c_int,
+        size_y: c_int,
+        rotate: c_int,
+        flags: c_int,
+    ),
+    extern_FPDF_RenderPageBitmapWithMatrix: unsafe extern "C" fn(
+        bitmap: FPDF_BITMAP,
+        page: FPDF_PAGE,
+        matrix: *const FS_MATRIX,
+        clipping: *const FS_RECTF,
+        flags: c_int,
+    ),
+    extern_FPDFAnnot_IsSupportedSubtype:
+        unsafe extern "C" fn(subtype: FPDF_ANNOTATION_SUBTYPE) -> FPDF_BOOL,
+    extern_FPDFPage_CreateAnnot:
+        unsafe extern "C" fn(page: FPDF_PAGE, subtype: FPDF_ANNOTATION_SUBTYPE) -> FPDF_ANNOTATION,
+    extern_FPDFPage_GetAnnotCount: unsafe extern "C" fn(page: FPDF_PAGE) -> c_int,
+    extern_FPDFPage_GetAnnot:
+        unsafe extern "C" fn(page: FPDF_PAGE, index: c_int) -> FPDF_ANNOTATION,
+    extern_FPDFPage_GetAnnotIndex:
+        unsafe extern "C" fn(page: FPDF_PAGE, annot: FPDF_ANNOTATION) -> c_int,
+    extern_FPDFPage_CloseAnnot: unsafe extern "C" fn(annot: FPDF_ANNOTATION),
+    extern_FPDFPage_RemoveAnnot: unsafe extern "C" fn(page: FPDF_PAGE, index: c_int) -> FPDF_BOOL,
+    extern_FPDFAnnot_GetSubtype:
+        unsafe extern "C" fn(annot: FPDF_ANNOTATION) -> FPDF_ANNOTATION_SUBTYPE,
+    extern_FPDFAnnot_IsObjectSupportedSubtype:
+        unsafe extern "C" fn(subtype: FPDF_ANNOTATION_SUBTYPE) -> FPDF_BOOL,
+    extern_FPDFAnnot_UpdateObject:
+        unsafe extern "C" fn(annot: FPDF_ANNOTATION, obj: FPDF_PAGEOBJECT) -> FPDF_BOOL,
+    extern_FPDFAnnot_AddInkStroke: unsafe extern "C" fn(
+        annot: FPDF_ANNOTATION,
+        points: *const FS_POINTF,
+        point_count: size_t,
+    ) -> c_int,
+    extern_FPDFAnnot_RemoveInkList: unsafe extern "C" fn(annot: FPDF_ANNOTATION) -> FPDF_BOOL,
+    extern_FPDFAnnot_AppendObject:
+        unsafe extern "C" fn(annot: FPDF_ANNOTATION, obj: FPDF_PAGEOBJECT) -> FPDF_BOOL,
+    extern_FPDFAnnot_GetObjectCount: unsafe extern "C" fn(annot: FPDF_ANNOTATION) -> c_int,
+    extern_FPDFAnnot_GetObject:
+        unsafe extern "C" fn(annot: FPDF_ANNOTATION, index: c_int) -> FPDF_PAGEOBJECT,
+    extern_FPDFAnnot_RemoveObject:
+        unsafe extern "C" fn(annot: FPDF_ANNOTATION, index: c_int) -> FPDF_BOOL,
+    extern_FPDFAnnot_SetColor: unsafe extern "C" fn(
+        annot: FPDF_ANNOTATION,
+        color_type: FPDFANNOT_COLORTYPE,
+        R: c_uint,
+        G: c_uint,
+        B: c_uint,
+        A: c_uint,
+    ) -> FPDF_BOOL,
+    extern_FPDFAnnot_GetColor: unsafe extern "C" fn(
+        annot: FPDF_ANNOTATION,
+        color_type: FPDFANNOT_COLORTYPE,
+        R: *mut c_uint,
+        G: *mut c_uint,
+        B: *mut c_uint,
+        A: *mut c_uint,
+    ) -> FPDF_BOOL,
+    extern_FPDFAnnot_HasAttachmentPoints: unsafe extern "C" fn(annot: FPDF_ANNOTATION) -> FPDF_BOOL,
+    extern_FPDFAnnot_SetAttachmentPoints: unsafe extern "C" fn(
+        annot: FPDF_ANNOTATION,
+        quad_index: size_t,
+        quad_points: *const FS_QUADPOINTSF,
+    ) -> FPDF_BOOL,
+    extern_FPDFAnnot_AppendAttachmentPoints: unsafe extern "C" fn(
+        annot: FPDF_ANNOTATION,
+        quad_points: *const FS_QUADPOINTSF,
+    ) -> FPDF_BOOL,
+    extern_FPDFAnnot_CountAttachmentPoints: unsafe extern "C" fn(annot: FPDF_ANNOTATION) -> size_t,
+    extern_FPDFAnnot_GetAttachmentPoints: unsafe extern "C" fn(
+        annot: FPDF_ANNOTATION,
+        quad_index: size_t,
+        quad_points: *mut FS_QUADPOINTSF,
+    ) -> FPDF_BOOL,
+    extern_FPDFAnnot_SetRect:
+        unsafe extern "C" fn(annot: FPDF_ANNOTATION, rect: *const FS_RECTF) -> FPDF_BOOL,
+    extern_FPDFAnnot_GetRect:
+        unsafe extern "C" fn(annot: FPDF_ANNOTATION, rect: *mut FS_RECTF) -> FPDF_BOOL,
+    extern_FPDFAnnot_GetVertices: unsafe extern "C" fn(
+        annot: FPDF_ANNOTATION,
+        buffer: *mut FS_POINTF,
+        length: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFAnnot_GetInkListCount: unsafe extern "C" fn(annot: FPDF_ANNOTATION) -> c_ulong,
+    extern_FPDFAnnot_GetInkListPath: unsafe extern "C" fn(
+        annot: FPDF_ANNOTATION,
+        path_index: c_ulong,
+        buffer: *mut FS_POINTF,
+        length: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFAnnot_GetLine: unsafe extern "C" fn(
+        annot: FPDF_ANNOTATION,
+        start: *mut FS_POINTF,
+        end: *mut FS_POINTF,
+    ) -> FPDF_BOOL,
+    extern_FPDFAnnot_SetBorder: unsafe extern "C" fn(
+        annot: FPDF_ANNOTATION,
+        horizontal_radius: f32,
+        vertical_radius: f32,
+        border_width: f32,
+    ) -> FPDF_BOOL,
+    extern_FPDFAnnot_GetBorder: unsafe extern "C" fn(
+        annot: FPDF_ANNOTATION,
+        horizontal_radius: *mut f32,
+        vertical_radius: *mut f32,
+        border_width: *mut f32,
+    ) -> FPDF_BOOL,
+    extern_FPDFAnnot_HasKey:
+        unsafe extern "C" fn(annot: FPDF_ANNOTATION, key: FPDF_BYTESTRING) -> FPDF_BOOL,
+    extern_FPDFAnnot_GetValueType:
+        unsafe extern "C" fn(annot: FPDF_ANNOTATION, key: FPDF_BYTESTRING) -> FPDF_OBJECT_TYPE,
+    extern_FPDFAnnot_SetStringValue: unsafe extern "C" fn(
+        annot: FPDF_ANNOTATION,
+        key: FPDF_BYTESTRING,
+        value: FPDF_WIDESTRING,
+    ) -> FPDF_BOOL,
+    extern_FPDFAnnot_GetStringValue: unsafe extern "C" fn(
+        annot: FPDF_ANNOTATION,
+        key: FPDF_BYTESTRING,
+        buffer: *mut FPDF_WCHAR,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFAnnot_GetNumberValue: unsafe extern "C" fn(
+        annot: FPDF_ANNOTATION,
+        key: FPDF_BYTESTRING,
+        value: *mut f32,
+    ) -> FPDF_BOOL,
+    extern_FPDFAnnot_SetAP: unsafe extern "C" fn(
+        annot: FPDF_ANNOTATION,
+        appearanceMode: FPDF_ANNOT_APPEARANCEMODE,
+        value: FPDF_WIDESTRING,
+    ) -> FPDF_BOOL,
+    extern_FPDFAnnot_GetAP: unsafe extern "C" fn(
+        annot: FPDF_ANNOTATION,
+        appearanceMode: FPDF_ANNOT_APPEARANCEMODE,
+        buffer: *mut FPDF_WCHAR,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFAnnot_GetLinkedAnnot:
+        unsafe extern "C" fn(annot: FPDF_ANNOTATION, key: FPDF_BYTESTRING) -> FPDF_ANNOTATION,
+    extern_FPDFAnnot_GetFlags: unsafe extern "C" fn(annot: FPDF_ANNOTATION) -> c_int,
+    extern_FPDFAnnot_SetFlags:
+        unsafe extern "C" fn(annot: FPDF_ANNOTATION, flags: c_int) -> FPDF_BOOL,
+    extern_FPDFAnnot_GetFormFieldFlags:
+        unsafe extern "C" fn(handle: FPDF_FORMHANDLE, annot: FPDF_ANNOTATION) -> c_int,
+    extern_FPDFAnnot_GetFormFieldAtPoint: unsafe extern "C" fn(
+        hHandle: FPDF_FORMHANDLE,
+        page: FPDF_PAGE,
+        point: *const FS_POINTF,
+    ) -> FPDF_ANNOTATION,
+    extern_FPDFAnnot_GetFormFieldName: unsafe extern "C" fn(
+        hHandle: FPDF_FORMHANDLE,
+        annot: FPDF_ANNOTATION,
+        buffer: *mut FPDF_WCHAR,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFAnnot_GetFormFieldType:
+        unsafe extern "C" fn(hHandle: FPDF_FORMHANDLE, annot: FPDF_ANNOTATION) -> c_int,
+    extern_FPDFAnnot_GetFormFieldValue: unsafe extern "C" fn(
+        hHandle: FPDF_FORMHANDLE,
+        annot: FPDF_ANNOTATION,
+        buffer: *mut FPDF_WCHAR,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFAnnot_GetOptionCount:
+        unsafe extern "C" fn(hHandle: FPDF_FORMHANDLE, annot: FPDF_ANNOTATION) -> c_int,
+    extern_FPDFAnnot_GetOptionLabel: unsafe extern "C" fn(
+        hHandle: FPDF_FORMHANDLE,
+        annot: FPDF_ANNOTATION,
+        index: c_int,
+        buffer: *mut FPDF_WCHAR,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFAnnot_IsOptionSelected: unsafe extern "C" fn(
+        handle: FPDF_FORMHANDLE,
+        annot: FPDF_ANNOTATION,
+        index: c_int,
+    ) -> FPDF_BOOL,
+    extern_FPDFAnnot_GetFontSize: unsafe extern "C" fn(
+        hHandle: FPDF_FORMHANDLE,
+        annot: FPDF_ANNOTATION,
+        value: *mut f32,
+    ) -> FPDF_BOOL,
+    extern_FPDFAnnot_IsChecked:
+        unsafe extern "C" fn(hHandle: FPDF_FORMHANDLE, annot: FPDF_ANNOTATION) -> FPDF_BOOL,
+    extern_FPDFAnnot_SetFocusableSubtypes: unsafe extern "C" fn(
+        hHandle: FPDF_FORMHANDLE,
+        subtypes: *const FPDF_ANNOTATION_SUBTYPE,
+        count: size_t,
+    ) -> FPDF_BOOL,
+    extern_FPDFAnnot_GetFocusableSubtypesCount:
+        unsafe extern "C" fn(hHandle: FPDF_FORMHANDLE) -> c_int,
+    extern_FPDFAnnot_GetFocusableSubtypes: unsafe extern "C" fn(
+        hHandle: FPDF_FORMHANDLE,
+        subtypes: *mut FPDF_ANNOTATION_SUBTYPE,
+        count: size_t,
+    ) -> FPDF_BOOL,
+    extern_FPDFAnnot_GetLink: unsafe extern "C" fn(annot: FPDF_ANNOTATION) -> FPDF_LINK,
+    extern_FPDFAnnot_GetFormControlCount:
+        unsafe extern "C" fn(hHandle: FPDF_FORMHANDLE, annot: FPDF_ANNOTATION) -> c_int,
+    extern_FPDFAnnot_GetFormControlIndex:
+        unsafe extern "C" fn(hHandle: FPDF_FORMHANDLE, annot: FPDF_ANNOTATION) -> c_int,
+    extern_FPDFAnnot_GetFormFieldExportValue: unsafe extern "C" fn(
+        hHandle: FPDF_FORMHANDLE,
+        annot: FPDF_ANNOTATION,
+        buffer: *mut FPDF_WCHAR,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFAnnot_SetURI:
+        unsafe extern "C" fn(annot: FPDF_ANNOTATION, uri: *const c_char) -> FPDF_BOOL,
+    extern_FPDFDOC_InitFormFillEnvironment: unsafe extern "C" fn(
+        document: FPDF_DOCUMENT,
+        form_info: *mut FPDF_FORMFILLINFO,
+    ) -> FPDF_FORMHANDLE,
+    extern_FPDFDOC_ExitFormFillEnvironment: unsafe extern "C" fn(handle: FPDF_FORMHANDLE),
+    extern_FORM_OnAfterLoadPage: unsafe extern "C" fn(page: FPDF_PAGE, handle: FPDF_FORMHANDLE),
+    extern_FORM_OnBeforeClosePage: unsafe extern "C" fn(page: FPDF_PAGE, handle: FPDF_FORMHANDLE),
+    extern_FPDFDoc_GetPageMode: unsafe extern "C" fn(document: FPDF_DOCUMENT) -> c_int,
+    extern_FPDFPage_Flatten: unsafe extern "C" fn(page: FPDF_PAGE, nFlag: c_int) -> c_int,
+    extern_FPDF_SetFormFieldHighlightColor:
+        unsafe extern "C" fn(handle: FPDF_FORMHANDLE, field_type: c_int, color: c_ulong),
+    extern_FPDF_SetFormFieldHighlightAlpha:
+        unsafe extern "C" fn(handle: FPDF_FORMHANDLE, alpha: c_uchar),
+    extern_FPDF_FFLDraw: unsafe extern "C" fn(
+        handle: FPDF_FORMHANDLE,
+        bitmap: FPDF_BITMAP,
+        page: FPDF_PAGE,
+        start_x: c_int,
+        start_y: c_int,
+        size_x: c_int,
+        size_y: c_int,
+        rotate: c_int,
+        flags: c_int,
+    ),
+    extern_FPDF_GetFormType: unsafe extern "C" fn(document: FPDF_DOCUMENT) -> c_int,
+    extern_FPDFBookmark_GetFirstChild:
+        unsafe extern "C" fn(document: FPDF_DOCUMENT, bookmark: FPDF_BOOKMARK) -> FPDF_BOOKMARK,
+    extern_FPDFBookmark_GetNextSibling:
+        unsafe extern "C" fn(document: FPDF_DOCUMENT, bookmark: FPDF_BOOKMARK) -> FPDF_BOOKMARK,
+    extern_FPDFBookmark_GetTitle: unsafe extern "C" fn(
+        bookmark: FPDF_BOOKMARK,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFBookmark_GetCount: unsafe extern "C" fn(bookmark: FPDF_BOOKMARK) -> c_int,
+    extern_FPDFBookmark_Find:
+        unsafe extern "C" fn(document: FPDF_DOCUMENT, title: FPDF_WIDESTRING) -> FPDF_BOOKMARK,
+    extern_FPDFBookmark_GetDest:
+        unsafe extern "C" fn(document: FPDF_DOCUMENT, bookmark: FPDF_BOOKMARK) -> FPDF_DEST,
+    extern_FPDFBookmark_GetAction: unsafe extern "C" fn(bookmark: FPDF_BOOKMARK) -> FPDF_ACTION,
+    extern_FPDFAction_GetType: unsafe extern "C" fn(action: FPDF_ACTION) -> c_ulong,
+    extern_FPDFAction_GetDest:
+        unsafe extern "C" fn(document: FPDF_DOCUMENT, action: FPDF_ACTION) -> FPDF_DEST,
+    extern_FPDFAction_GetFilePath:
+        unsafe extern "C" fn(action: FPDF_ACTION, buffer: *mut c_void, buflen: c_ulong) -> c_ulong,
+    extern_FPDFAction_GetURIPath: unsafe extern "C" fn(
+        document: FPDF_DOCUMENT,
+        action: FPDF_ACTION,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFDest_GetDestPageIndex:
+        unsafe extern "C" fn(document: FPDF_DOCUMENT, dest: FPDF_DEST) -> c_int,
+    extern_FPDFDest_GetView: unsafe extern "C" fn(
+        dest: FPDF_DEST,
+        pNumParams: *mut c_ulong,
+        pParams: *mut FS_FLOAT,
+    ) -> c_ulong,
+    extern_FPDFDest_GetLocationInPage: unsafe extern "C" fn(
+        dest: FPDF_DEST,
+        hasXVal: *mut FPDF_BOOL,
+        hasYVal: *mut FPDF_BOOL,
+        hasZoomVal: *mut FPDF_BOOL,
+        x: *mut FS_FLOAT,
+        y: *mut FS_FLOAT,
+        zoom: *mut FS_FLOAT,
+    ) -> FPDF_BOOL,
+    extern_FPDFLink_GetLinkAtPoint:
+        unsafe extern "C" fn(page: FPDF_PAGE, x: c_double, y: c_double) -> FPDF_LINK,
+    extern_FPDFLink_GetLinkZOrderAtPoint:
+        unsafe extern "C" fn(page: FPDF_PAGE, x: c_double, y: c_double) -> c_int,
+    extern_FPDFLink_GetDest:
+        unsafe extern "C" fn(document: FPDF_DOCUMENT, link: FPDF_LINK) -> FPDF_DEST,
+    extern_FPDFLink_GetAction: unsafe extern "C" fn(link: FPDF_LINK) -> FPDF_ACTION,
+    extern_FPDFLink_Enumerate: unsafe extern "C" fn(
+        page: FPDF_PAGE,
+        start_pos: *mut c_int,
+        link_annot: *mut FPDF_LINK,
+    ) -> FPDF_BOOL,
+    extern_FPDFLink_GetAnnot:
+        unsafe extern "C" fn(page: FPDF_PAGE, link_annot: FPDF_LINK) -> FPDF_ANNOTATION,
+    extern_FPDFLink_GetAnnotRect:
+        unsafe extern "C" fn(link_annot: FPDF_LINK, rect: *mut FS_RECTF) -> FPDF_BOOL,
+    extern_FPDFLink_CountQuadPoints: unsafe extern "C" fn(link_annot: FPDF_LINK) -> c_int,
+    extern_FPDFLink_GetQuadPoints: unsafe extern "C" fn(
+        link_annot: FPDF_LINK,
+        quad_index: c_int,
+        quad_points: *mut FS_QUADPOINTSF,
+    ) -> FPDF_BOOL,
+    extern_FPDF_GetPageAAction:
+        unsafe extern "C" fn(page: FPDF_PAGE, aa_type: c_int) -> FPDF_ACTION,
+    extern_FPDFText_LoadPage: unsafe extern "C" fn(page: FPDF_PAGE) -> FPDF_TEXTPAGE,
+    extern_FPDFText_ClosePage: unsafe extern "C" fn(text_page: FPDF_TEXTPAGE),
+    extern_FPDFText_CountChars: unsafe extern "C" fn(text_page: FPDF_TEXTPAGE) -> c_int,
+    extern_FPDFText_GetUnicode:
+        unsafe extern "C" fn(text_page: FPDF_TEXTPAGE, index: c_int) -> c_uint,
+    extern_FPDFText_GetFontSize:
+        unsafe extern "C" fn(text_page: FPDF_TEXTPAGE, index: c_int) -> c_double,
+    extern_FPDFText_GetFontInfo: unsafe extern "C" fn(
+        text_page: FPDF_TEXTPAGE,
+        index: c_int,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+        flags: *mut c_int,
+    ) -> c_ulong,
+    extern_FPDFText_GetFontWeight:
+        unsafe extern "C" fn(text_page: FPDF_TEXTPAGE, index: c_int) -> c_int,
+    extern_FPDFText_GetTextRenderMode:
+        unsafe extern "C" fn(text_page: FPDF_TEXTPAGE, index: c_int) -> FPDF_TEXT_RENDERMODE,
+    extern_FPDFText_GetFillColor: unsafe extern "C" fn(
+        text_page: FPDF_TEXTPAGE,
+        index: c_int,
+        R: *mut c_uint,
+        G: *mut c_uint,
+        B: *mut c_uint,
+        A: *mut c_uint,
+    ) -> FPDF_BOOL,
+    extern_FPDFText_GetStrokeColor: unsafe extern "C" fn(
+        text_page: FPDF_TEXTPAGE,
+        index: c_int,
+        R: *mut c_uint,
+        G: *mut c_uint,
+        B: *mut c_uint,
+        A: *mut c_uint,
+    ) -> FPDF_BOOL,
+    extern_FPDFText_GetCharAngle:
+        unsafe extern "C" fn(text_page: FPDF_TEXTPAGE, index: c_int) -> c_float,
+    extern_FPDFText_GetCharBox: unsafe extern "C" fn(
+        text_page: FPDF_TEXTPAGE,
+        index: c_int,
+        left: *mut c_double,
+        right: *mut c_double,
+        bottom: *mut c_double,
+        top: *mut c_double,
+    ) -> FPDF_BOOL,
+    extern_FPDFText_GetLooseCharBox: unsafe extern "C" fn(
+        text_page: FPDF_TEXTPAGE,
+        index: c_int,
+        rect: *mut FS_RECTF,
+    ) -> FPDF_BOOL,
+    extern_FPDFText_GetMatrix: unsafe extern "C" fn(
+        text_page: FPDF_TEXTPAGE,
+        index: c_int,
+        matrix: *mut FS_MATRIX,
+    ) -> FPDF_BOOL,
+    extern_FPDFText_GetCharOrigin: unsafe extern "C" fn(
+        text_page: FPDF_TEXTPAGE,
+        index: c_int,
+        x: *mut c_double,
+        y: *mut c_double,
+    ) -> FPDF_BOOL,
+    extern_FPDFText_GetCharIndexAtPos: unsafe extern "C" fn(
+        text_page: FPDF_TEXTPAGE,
+        x: c_double,
+        y: c_double,
+        xTolerance: c_double,
+        yTolerance: c_double,
+    ) -> c_int,
+    extern_FPDFText_GetText: unsafe extern "C" fn(
+        text_page: FPDF_TEXTPAGE,
+        start_index: c_int,
+        count: c_int,
+        result: *mut c_ushort,
+    ) -> c_int,
+    extern_FPDFText_CountRects:
+        unsafe extern "C" fn(text_page: FPDF_TEXTPAGE, start_index: c_int, count: c_int) -> c_int,
+    extern_FPDFText_GetRect: unsafe extern "C" fn(
+        text_page: FPDF_TEXTPAGE,
+        rect_index: c_int,
+        left: *mut c_double,
+        top: *mut c_double,
+        right: *mut c_double,
+        bottom: *mut c_double,
+    ) -> FPDF_BOOL,
+    extern_FPDFText_GetBoundedText: unsafe extern "C" fn(
+        text_page: FPDF_TEXTPAGE,
+        left: c_double,
+        top: c_double,
+        right: c_double,
+        bottom: c_double,
+        buffer: *mut c_ushort,
+        buflen: c_int,
+    ) -> c_int,
+    extern_FPDFText_FindStart: unsafe extern "C" fn(
+        text_page: FPDF_TEXTPAGE,
+        findwhat: FPDF_WIDESTRING,
+        flags: c_ulong,
+        start_index: c_int,
+    ) -> FPDF_SCHHANDLE,
+    extern_FPDFText_FindNext: unsafe extern "C" fn(handle: FPDF_SCHHANDLE) -> FPDF_BOOL,
+    extern_FPDFText_FindPrev: unsafe extern "C" fn(handle: FPDF_SCHHANDLE) -> FPDF_BOOL,
+    extern_FPDFText_GetSchResultIndex: unsafe extern "C" fn(handle: FPDF_SCHHANDLE) -> c_int,
+    extern_FPDFText_GetSchCount: unsafe extern "C" fn(handle: FPDF_SCHHANDLE) -> c_int,
+    extern_FPDFText_FindClose: unsafe extern "C" fn(handle: FPDF_SCHHANDLE),
+    extern_FPDFLink_LoadWebLinks: unsafe extern "C" fn(text_page: FPDF_TEXTPAGE) -> FPDF_PAGELINK,
+    extern_FPDFLink_CountWebLinks: unsafe extern "C" fn(link_page: FPDF_PAGELINK) -> c_int,
+    extern_FPDFLink_GetURL: unsafe extern "C" fn(
+        link_page: FPDF_PAGELINK,
+        link_index: c_int,
+        buffer: *mut c_ushort,
+        buflen: c_int,
+    ) -> c_int,
+    extern_FPDFLink_CountRects:
+        unsafe extern "C" fn(link_page: FPDF_PAGELINK, link_index: c_int) -> c_int,
+    extern_FPDFLink_GetRect: unsafe extern "C" fn(
+        link_page: FPDF_PAGELINK,
+        link_index: c_int,
+        rect_index: c_int,
+        left: *mut c_double,
+        top: *mut c_double,
+        right: *mut c_double,
+        bottom: *mut c_double,
+    ) -> FPDF_BOOL,
+    extern_FPDFLink_GetTextRange: unsafe extern "C" fn(
+        link_page: FPDF_PAGELINK,
+        link_index: c_int,
+        start_char_index: *mut c_int,
+        char_count: *mut c_int,
+    ) -> FPDF_BOOL,
+    extern_FPDFLink_CloseWebLinks: unsafe extern "C" fn(link_page: FPDF_PAGELINK),
+    extern_FPDFPage_GetDecodedThumbnailData:
+        unsafe extern "C" fn(page: FPDF_PAGE, buffer: *mut c_void, buflen: c_ulong) -> c_ulong,
+    extern_FPDFPage_GetRawThumbnailData:
+        unsafe extern "C" fn(page: FPDF_PAGE, buffer: *mut c_void, buflen: c_ulong) -> c_ulong,
+    extern_FPDFPage_GetThumbnailAsBitmap: unsafe extern "C" fn(page: FPDF_PAGE) -> FPDF_BITMAP,
+    extern_FPDFFormObj_CountObjects: unsafe extern "C" fn(form_object: FPDF_PAGEOBJECT) -> c_int,
+    extern_FPDFFormObj_GetObject:
+        unsafe extern "C" fn(form_object: FPDF_PAGEOBJECT, index: c_ulong) -> FPDF_PAGEOBJECT,
+    extern_FPDFPageObj_CreateTextObj: unsafe extern "C" fn(
+        document: FPDF_DOCUMENT,
+        font: FPDF_FONT,
+        font_size: c_float,
+    ) -> FPDF_PAGEOBJECT,
+    extern_FPDFTextObj_GetTextRenderMode:
+        unsafe extern "C" fn(text: FPDF_PAGEOBJECT) -> FPDF_TEXT_RENDERMODE,
+    extern_FPDFTextObj_SetTextRenderMode:
+        unsafe extern "C" fn(text: FPDF_PAGEOBJECT, render_mode: FPDF_TEXT_RENDERMODE) -> FPDF_BOOL,
+    extern_FPDFTextObj_GetText: unsafe extern "C" fn(
+        text_object: FPDF_PAGEOBJECT,
+        text_page: FPDF_TEXTPAGE,
+        buffer: *mut FPDF_WCHAR,
+        length: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFTextObj_GetFont: unsafe extern "C" fn(text: FPDF_PAGEOBJECT) -> FPDF_FONT,
+    extern_FPDFTextObj_GetFontSize:
+        unsafe extern "C" fn(text: FPDF_PAGEOBJECT, size: *mut c_float) -> FPDF_BOOL,
+    extern_FPDFPageObj_NewTextObj: unsafe extern "C" fn(
+        document: FPDF_DOCUMENT,
+        font: FPDF_BYTESTRING,
+        font_size: c_float,
+    ) -> FPDF_PAGEOBJECT,
+    extern_FPDFText_SetText:
+        unsafe extern "C" fn(text_object: FPDF_PAGEOBJECT, text: FPDF_WIDESTRING) -> FPDF_BOOL,
+    extern_FPDFText_SetCharcodes: unsafe extern "C" fn(
+        text_object: FPDF_PAGEOBJECT,
+        charcodes: *const c_uint,
+        count: size_t,
+    ) -> FPDF_BOOL,
+    extern_FPDFText_LoadFont: unsafe extern "C" fn(
+        document: FPDF_DOCUMENT,
+        data: *const c_uchar,
+        size: c_uint,
+        font_type: c_int,
+        cid: FPDF_BOOL,
+    ) -> FPDF_FONT,
+    extern_FPDFText_LoadStandardFont:
+        unsafe extern "C" fn(document: FPDF_DOCUMENT, font: FPDF_BYTESTRING) -> FPDF_FONT,
+    extern_FPDFFont_Close: unsafe extern "C" fn(font: FPDF_FONT),
+    extern_FPDFPath_MoveTo:
+        unsafe extern "C" fn(path: FPDF_PAGEOBJECT, x: c_float, y: c_float) -> FPDF_BOOL,
+    extern_FPDFPath_LineTo:
+        unsafe extern "C" fn(path: FPDF_PAGEOBJECT, x: c_float, y: c_float) -> FPDF_BOOL,
+    extern_FPDFPath_BezierTo: unsafe extern "C" fn(
+        path: FPDF_PAGEOBJECT,
+        x1: c_float,
+        y1: c_float,
+        x2: c_float,
+        y2: c_float,
+        x3: c_float,
+        y3: c_float,
+    ) -> FPDF_BOOL,
+    extern_FPDFPath_Close: unsafe extern "C" fn(path: FPDF_PAGEOBJECT) -> FPDF_BOOL,
+    extern_FPDFPath_SetDrawMode: unsafe extern "C" fn(
+        path: FPDF_PAGEOBJECT,
+        fillmode: c_int,
+        stroke: FPDF_BOOL,
+    ) -> FPDF_BOOL,
+    extern_FPDFPath_GetDrawMode: unsafe extern "C" fn(
+        path: FPDF_PAGEOBJECT,
+        fillmode: *mut c_int,
+        stroke: *mut FPDF_BOOL,
+    ) -> FPDF_BOOL,
+    extern_FPDFPage_InsertObject: unsafe extern "C" fn(page: FPDF_PAGE, page_obj: FPDF_PAGEOBJECT),
+    extern_FPDFPage_RemoveObject:
+        unsafe extern "C" fn(page: FPDF_PAGE, page_obj: FPDF_PAGEOBJECT) -> FPDF_BOOL,
+    extern_FPDFPage_CountObjects: unsafe extern "C" fn(page: FPDF_PAGE) -> c_int,
+    extern_FPDFPage_GetObject:
+        unsafe extern "C" fn(page: FPDF_PAGE, index: c_int) -> FPDF_PAGEOBJECT,
+    extern_FPDFPageObj_Destroy: unsafe extern "C" fn(page_obj: FPDF_PAGEOBJECT),
+    extern_FPDFPageObj_HasTransparency:
+        unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT) -> FPDF_BOOL,
+    extern_FPDFPageObj_GetType: unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT) -> c_int,
+    extern_FPDFPageObj_Transform: unsafe extern "C" fn(
+        page_object: FPDF_PAGEOBJECT,
+        a: c_double,
+        b: c_double,
+        c: c_double,
+        d: c_double,
+        e: c_double,
+        f: c_double,
+    ),
+    extern_FPDFPageObj_GetMatrix:
+        unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT, matrix: *mut FS_MATRIX) -> FPDF_BOOL,
+    extern_FPDFPageObj_SetMatrix:
+        unsafe extern "C" fn(path: FPDF_PAGEOBJECT, matrix: *const FS_MATRIX) -> FPDF_BOOL,
+    extern_FPDFPageObj_NewImageObj:
+        unsafe extern "C" fn(document: FPDF_DOCUMENT) -> FPDF_PAGEOBJECT,
+    extern_FPDFPageObj_CountMarks: unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT) -> c_int,
+    extern_FPDFPageObj_GetMark:
+        unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT, index: c_ulong) -> FPDF_PAGEOBJECTMARK,
+    extern_FPDFPageObj_AddMark: unsafe extern "C" fn(
+        page_object: FPDF_PAGEOBJECT,
+        name: FPDF_BYTESTRING,
+    ) -> FPDF_PAGEOBJECTMARK,
+    extern_FPDFPageObj_RemoveMark:
+        unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT, mark: FPDF_PAGEOBJECTMARK) -> FPDF_BOOL,
+    extern_FPDFPageObjMark_GetName: unsafe extern "C" fn(
+        mark: FPDF_PAGEOBJECTMARK,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+        out_buflen: *mut c_ulong,
+    ) -> FPDF_BOOL,
+    extern_FPDFPageObjMark_CountParams: unsafe extern "C" fn(mark: FPDF_PAGEOBJECTMARK) -> c_int,
+    extern_FPDFPageObjMark_GetParamKey: unsafe extern "C" fn(
+        mark: FPDF_PAGEOBJECTMARK,
+        index: c_ulong,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+        out_buflen: *mut c_ulong,
+    ) -> FPDF_BOOL,
+    extern_FPDFPageObjMark_GetParamValueType:
+        unsafe extern "C" fn(mark: FPDF_PAGEOBJECTMARK, key: FPDF_BYTESTRING) -> FPDF_OBJECT_TYPE,
+    extern_FPDFPageObjMark_GetParamIntValue: unsafe extern "C" fn(
+        mark: FPDF_PAGEOBJECTMARK,
+        key: FPDF_BYTESTRING,
+        out_value: *mut c_int,
+    ) -> FPDF_BOOL,
+    extern_FPDFPageObjMark_GetParamStringValue: unsafe extern "C" fn(
+        mark: FPDF_PAGEOBJECTMARK,
+        key: FPDF_BYTESTRING,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+        out_buflen: *mut c_ulong,
+    ) -> FPDF_BOOL,
+    extern_FPDFPageObjMark_GetParamBlobValue: unsafe extern "C" fn(
+        mark: FPDF_PAGEOBJECTMARK,
+        key: FPDF_BYTESTRING,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+        out_buflen: *mut c_ulong,
+    ) -> FPDF_BOOL,
+    extern_FPDFPageObjMark_SetIntParam: unsafe extern "C" fn(
+        document: FPDF_DOCUMENT,
+        page_object: FPDF_PAGEOBJECT,
+        mark: FPDF_PAGEOBJECTMARK,
+        key: FPDF_BYTESTRING,
+        value: c_int,
+    ) -> FPDF_BOOL,
+    extern_FPDFPageObjMark_SetStringParam: unsafe extern "C" fn(
+        document: FPDF_DOCUMENT,
+        page_object: FPDF_PAGEOBJECT,
+        mark: FPDF_PAGEOBJECTMARK,
+        key: FPDF_BYTESTRING,
+        value: FPDF_BYTESTRING,
+    ) -> FPDF_BOOL,
+    extern_FPDFPageObjMark_SetBlobParam: unsafe extern "C" fn(
+        document: FPDF_DOCUMENT,
+        page_object: FPDF_PAGEOBJECT,
+        mark: FPDF_PAGEOBJECTMARK,
+        key: FPDF_BYTESTRING,
+        value: *mut c_void,
+        value_len: c_ulong,
+    ) -> FPDF_BOOL,
+    extern_FPDFPageObjMark_RemoveParam: unsafe extern "C" fn(
+        page_object: FPDF_PAGEOBJECT,
+        mark: FPDF_PAGEOBJECTMARK,
+        key: FPDF_BYTESTRING,
+    ) -> FPDF_BOOL,
+    extern_FPDFImageObj_LoadJpegFile: unsafe extern "C" fn(
+        pages: *mut FPDF_PAGE,
+        count: c_int,
+        image_object: FPDF_PAGEOBJECT,
+        file_access: *mut FPDF_FILEACCESS,
+    ) -> FPDF_BOOL,
+    extern_FPDFImageObj_LoadJpegFileInline: unsafe extern "C" fn(
+        pages: *mut FPDF_PAGE,
+        count: c_int,
+        image_object: FPDF_PAGEOBJECT,
+        file_access: *mut FPDF_FILEACCESS,
+    ) -> FPDF_BOOL,
+    extern_FPDFImageObj_SetMatrix: unsafe extern "C" fn(
+        image_object: FPDF_PAGEOBJECT,
+        a: c_double,
+        b: c_double,
+        c: c_double,
+        d: c_double,
+        e: c_double,
+        f: c_double,
+    ) -> FPDF_BOOL,
+    extern_FPDFImageObj_SetBitmap: unsafe extern "C" fn(
+        pages: *mut FPDF_PAGE,
+        count: c_int,
+        image_object: FPDF_PAGEOBJECT,
+        bitmap: FPDF_BITMAP,
+    ) -> FPDF_BOOL,
+    extern_FPDFImageObj_GetBitmap:
+        unsafe extern "C" fn(image_object: FPDF_PAGEOBJECT) -> FPDF_BITMAP,
+    extern_FPDFImageObj_GetRenderedBitmap: unsafe extern "C" fn(
+        document: FPDF_DOCUMENT,
+        page: FPDF_PAGE,
+        image_object: FPDF_PAGEOBJECT,
+    ) -> FPDF_BITMAP,
+    extern_FPDFImageObj_GetImageDataDecoded: unsafe extern "C" fn(
+        image_object: FPDF_PAGEOBJECT,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFImageObj_GetImageDataRaw: unsafe extern "C" fn(
+        image_object: FPDF_PAGEOBJECT,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFImageObj_GetImageFilterCount:
+        unsafe extern "C" fn(image_object: FPDF_PAGEOBJECT) -> c_int,
+    extern_FPDFImageObj_GetImageFilter: unsafe extern "C" fn(
+        image_object: FPDF_PAGEOBJECT,
+        index: c_int,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFImageObj_GetImageMetadata: unsafe extern "C" fn(
+        image_object: FPDF_PAGEOBJECT,
+        page: FPDF_PAGE,
+        metadata: *mut FPDF_IMAGEOBJ_METADATA,
+    ) -> FPDF_BOOL,
+    extern_FPDFPageObj_CreateNewPath:
+        unsafe extern "C" fn(x: c_float, y: c_float) -> FPDF_PAGEOBJECT,
+    extern_FPDFPageObj_CreateNewRect:
+        unsafe extern "C" fn(x: c_float, y: c_float, w: c_float, h: c_float) -> FPDF_PAGEOBJECT,
+    extern_FPDFPageObj_GetBounds: unsafe extern "C" fn(
+        page_object: FPDF_PAGEOBJECT,
+        left: *mut c_float,
+        bottom: *mut c_float,
+        right: *mut c_float,
+        top: *mut c_float,
+    ) -> FPDF_BOOL,
+    extern_FPDFPageObj_SetBlendMode:
+        unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT, blend_mode: FPDF_BYTESTRING),
+    extern_FPDFPageObj_SetStrokeColor: unsafe extern "C" fn(
+        page_object: FPDF_PAGEOBJECT,
+        R: c_uint,
+        G: c_uint,
+        B: c_uint,
+        A: c_uint,
+    ) -> FPDF_BOOL,
+    extern_FPDFPageObj_GetStrokeColor: unsafe extern "C" fn(
+        page_object: FPDF_PAGEOBJECT,
+        R: *mut c_uint,
+        G: *mut c_uint,
+        B: *mut c_uint,
+        A: *mut c_uint,
+    ) -> FPDF_BOOL,
+    extern_FPDFPageObj_SetStrokeWidth:
+        unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT, width: c_float) -> FPDF_BOOL,
+    extern_FPDFPageObj_GetStrokeWidth:
+        unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT, width: *mut c_float) -> FPDF_BOOL,
+    extern_FPDFPageObj_GetLineJoin: unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT) -> c_int,
+    extern_FPDFPageObj_SetLineJoin:
+        unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT, line_join: c_int) -> FPDF_BOOL,
+    extern_FPDFPageObj_GetLineCap: unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT) -> c_int,
+    extern_FPDFPageObj_SetLineCap:
+        unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT, line_cap: c_int) -> FPDF_BOOL,
+    extern_FPDFPageObj_SetFillColor: unsafe extern "C" fn(
+        page_object: FPDF_PAGEOBJECT,
+        R: c_uint,
+        G: c_uint,
+        B: c_uint,
+        A: c_uint,
+    ) -> FPDF_BOOL,
+    extern_FPDFPageObj_GetFillColor: unsafe extern "C" fn(
+        page_object: FPDF_PAGEOBJECT,
+        R: *mut c_uint,
+        G: *mut c_uint,
+        B: *mut c_uint,
+        A: *mut c_uint,
+    ) -> FPDF_BOOL,
+    extern_FPDFPageObj_GetDashPhase:
+        unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT, phase: *mut c_float) -> FPDF_BOOL,
+    extern_FPDFPageObj_SetDashPhase:
+        unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT, phase: c_float) -> FPDF_BOOL,
+    extern_FPDFPageObj_GetDashCount: unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT) -> c_int,
+    extern_FPDFPageObj_GetDashArray: unsafe extern "C" fn(
+        page_object: FPDF_PAGEOBJECT,
+        dash_array: *mut c_float,
+        dash_count: size_t,
+    ) -> FPDF_BOOL,
+    extern_FPDFPageObj_SetDashArray: unsafe extern "C" fn(
+        page_object: FPDF_PAGEOBJECT,
+        dash_array: *const c_float,
+        dash_count: size_t,
+        phase: c_float,
+    ) -> FPDF_BOOL,
+    extern_FPDFPath_CountSegments: unsafe extern "C" fn(path: FPDF_PAGEOBJECT) -> c_int,
+    extern_FPDFPath_GetPathSegment:
+        unsafe extern "C" fn(path: FPDF_PAGEOBJECT, index: c_int) -> FPDF_PATHSEGMENT,
+    extern_FPDFPathSegment_GetPoint:
+        unsafe extern "C" fn(segment: FPDF_PATHSEGMENT, x: *mut f32, y: *mut f32) -> FPDF_BOOL,
+    extern_FPDFPathSegment_GetType: unsafe extern "C" fn(segment: FPDF_PATHSEGMENT) -> c_int,
+    extern_FPDFPathSegment_GetClose: unsafe extern "C" fn(segment: FPDF_PATHSEGMENT) -> FPDF_BOOL,
+    extern_FPDFFont_GetFontName:
+        unsafe extern "C" fn(font: FPDF_FONT, buffer: *mut c_char, length: c_ulong) -> c_ulong,
+    extern_FPDFFont_GetFlags: unsafe extern "C" fn(font: FPDF_FONT) -> c_int,
+    extern_FPDFFont_GetWeight: unsafe extern "C" fn(font: FPDF_FONT) -> c_int,
+    extern_FPDFFont_GetItalicAngle:
+        unsafe extern "C" fn(font: FPDF_FONT, angle: *mut c_int) -> FPDF_BOOL,
+    extern_FPDFFont_GetAscent: unsafe extern "C" fn(
+        font: FPDF_FONT,
+        font_size: c_float,
+        ascent: *mut c_float,
+    ) -> FPDF_BOOL,
+    extern_FPDFFont_GetDescent: unsafe extern "C" fn(
+        font: FPDF_FONT,
+        font_size: c_float,
+        descent: *mut c_float,
+    ) -> FPDF_BOOL,
+    extern_FPDFFont_GetGlyphWidth: unsafe extern "C" fn(
+        font: FPDF_FONT,
+        glyph: c_uint,
+        font_size: c_float,
+        width: *mut c_float,
+    ) -> FPDF_BOOL,
+    extern_FPDFFont_GetGlyphPath:
+        unsafe extern "C" fn(font: FPDF_FONT, glyph: c_uint, font_size: c_float) -> FPDF_GLYPHPATH,
+    extern_FPDFGlyphPath_CountGlyphSegments:
+        unsafe extern "C" fn(glyphpath: FPDF_GLYPHPATH) -> c_int,
+    extern_FPDFGlyphPath_GetGlyphPathSegment:
+        unsafe extern "C" fn(glyphpath: FPDF_GLYPHPATH, index: c_int) -> FPDF_PATHSEGMENT,
+    extern_FPDF_VIEWERREF_GetPrintScaling:
+        unsafe extern "C" fn(document: FPDF_DOCUMENT) -> FPDF_BOOL,
+    extern_FPDF_VIEWERREF_GetNumCopies: unsafe extern "C" fn(document: FPDF_DOCUMENT) -> c_int,
+    extern_FPDF_VIEWERREF_GetPrintPageRange:
+        unsafe extern "C" fn(document: FPDF_DOCUMENT) -> FPDF_PAGERANGE,
+    extern_FPDF_VIEWERREF_GetPrintPageRangeCount:
+        unsafe extern "C" fn(pagerange: FPDF_PAGERANGE) -> size_t,
+    extern_FPDF_VIEWERREF_GetPrintPageRangeElement:
+        unsafe extern "C" fn(pagerange: FPDF_PAGERANGE, index: size_t) -> c_int,
+    extern_FPDF_VIEWERREF_GetDuplex:
+        unsafe extern "C" fn(document: FPDF_DOCUMENT) -> FPDF_DUPLEXTYPE,
+    extern_FPDF_VIEWERREF_GetName: unsafe extern "C" fn(
+        document: FPDF_DOCUMENT,
+        key: FPDF_BYTESTRING,
+        buffer: *mut c_char,
+        length: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFDoc_GetAttachmentCount: unsafe extern "C" fn(document: FPDF_DOCUMENT) -> c_int,
+    extern_FPDFDoc_AddAttachment:
+        unsafe extern "C" fn(document: FPDF_DOCUMENT, name: FPDF_WIDESTRING) -> FPDF_ATTACHMENT,
+    extern_FPDFDoc_GetAttachment:
+        unsafe extern "C" fn(document: FPDF_DOCUMENT, index: c_int) -> FPDF_ATTACHMENT,
+    extern_FPDFDoc_DeleteAttachment:
+        unsafe extern "C" fn(document: FPDF_DOCUMENT, index: c_int) -> FPDF_BOOL,
+    extern_FPDFAttachment_GetName: unsafe extern "C" fn(
+        attachment: FPDF_ATTACHMENT,
+        buffer: *mut FPDF_WCHAR,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFAttachment_HasKey:
+        unsafe extern "C" fn(attachment: FPDF_ATTACHMENT, key: FPDF_BYTESTRING) -> FPDF_BOOL,
+    extern_FPDFAttachment_GetValueType:
+        unsafe extern "C" fn(attachment: FPDF_ATTACHMENT, key: FPDF_BYTESTRING) -> FPDF_OBJECT_TYPE,
+    extern_FPDFAttachment_SetStringValue: unsafe extern "C" fn(
+        attachment: FPDF_ATTACHMENT,
+        key: FPDF_BYTESTRING,
+        value: FPDF_WIDESTRING,
+    ) -> FPDF_BOOL,
+    extern_FPDFAttachment_GetStringValue: unsafe extern "C" fn(
+        attachment: FPDF_ATTACHMENT,
+        key: FPDF_BYTESTRING,
+        buffer: *mut FPDF_WCHAR,
+        buflen: c_ulong,
+    ) -> c_ulong,
+    extern_FPDFAttachment_SetFile: unsafe extern "C" fn(
+        attachment: FPDF_ATTACHMENT,
+        document: FPDF_DOCUMENT,
+        contents: *const c_void,
+        len: c_ulong,
+    ) -> FPDF_BOOL,
+    extern_FPDFAttachment_GetFile: unsafe extern "C" fn(
+        attachment: FPDF_ATTACHMENT,
+        buffer: *mut c_void,
+        buflen: c_ulong,
+        out_buflen: *mut c_ulong,
+    ) -> FPDF_BOOL,
+    extern_FPDFCatalog_IsTagged: unsafe extern "C" fn(document: FPDF_DOCUMENT) -> FPDF_BOOL,
 }
 
 impl DynamicPdfiumBindings {
     pub fn new(library: Library) -> Result<Self, libloading::Error> {
-        let result = DynamicPdfiumBindings { library };
-
-        // Make sure the library correctly exports all the functions we expect.
-
-        result.extern_FPDF_InitLibrary()?;
-        result.extern_FPDF_DestroyLibrary()?;
-        result.extern_FPDF_GetLastError()?;
-        result.extern_FPDF_CreateNewDocument()?;
-        result.extern_FPDF_LoadDocument()?;
-        result.extern_FPDF_LoadMemDocument64()?;
-        result.extern_FPDF_LoadCustomDocument()?;
-        result.extern_FPDF_SaveAsCopy()?;
-        result.extern_FPDF_SaveWithVersion()?;
-        result.extern_FPDF_CloseDocument()?;
-        result.extern_FPDF_DeviceToPage()?;
-        result.extern_FPDF_PageToDevice()?;
-        result.extern_FPDF_GetFileVersion()?;
-        result.extern_FPDF_GetFileIdentifier()?;
-        result.extern_FPDF_GetFormType()?;
-        result.extern_FPDF_GetMetaText()?;
-        result.extern_FPDF_GetDocPermissions()?;
-        result.extern_FPDF_GetSecurityHandlerRevision()?;
-        result.extern_FPDF_GetPageCount()?;
-        result.extern_FPDF_LoadPage()?;
-        result.extern_FPDF_ClosePage()?;
-        result.extern_FPDF_ImportPagesByIndex()?;
-        result.extern_FPDF_ImportPages()?;
-        result.extern_FPDF_ImportNPagesToOne()?;
-        result.extern_FPDF_GetPageLabel()?;
-        result.extern_FPDF_GetPageBoundingBox()?;
-        result.extern_FPDF_GetPageSizeByIndexF()?;
-        result.extern_FPDF_GetPageWidthF()?;
-        result.extern_FPDF_GetPageHeightF()?;
-        result.extern_FPDFText_GetCharIndexFromTextIndex()?;
-        result.extern_FPDFText_GetTextIndexFromCharIndex()?;
-        result.extern_FPDF_GetSignatureCount()?;
-        result.extern_FPDF_GetSignatureObject()?;
-        result.extern_FPDFSignatureObj_GetContents()?;
-        result.extern_FPDFSignatureObj_GetByteRange()?;
-        result.extern_FPDFSignatureObj_GetSubFilter()?;
-        result.extern_FPDFSignatureObj_GetReason()?;
-        result.extern_FPDFSignatureObj_GetTime()?;
-        result.extern_FPDFSignatureObj_GetDocMDPPermission()?;
-        result.extern_FPDF_StructTree_GetForPage()?;
-        result.extern_FPDF_StructTree_Close()?;
-        result.extern_FPDF_StructTree_CountChildren()?;
-        result.extern_FPDF_StructTree_GetChildAtIndex()?;
-        result.extern_FPDF_StructElement_GetAltText()?;
-        result.extern_FPDF_StructElement_GetID()?;
-        result.extern_FPDF_StructElement_GetLang()?;
-        result.extern_FPDF_StructElement_GetStringAttribute()?;
-        result.extern_FPDF_StructElement_GetMarkedContentID()?;
-        result.extern_FPDF_StructElement_GetType()?;
-        result.extern_FPDF_StructElement_GetTitle()?;
-        result.extern_FPDF_StructElement_CountChildren()?;
-        result.extern_FPDF_StructElement_GetChildAtIndex()?;
-        result.extern_FPDFPage_New()?;
-        result.extern_FPDFPage_Delete()?;
-        result.extern_FPDFPage_GetRotation()?;
-        result.extern_FPDFPage_SetRotation()?;
-        result.extern_FPDFPage_GetMediaBox()?;
-        result.extern_FPDFPage_GetCropBox()?;
-        result.extern_FPDFPage_GetBleedBox()?;
-        result.extern_FPDFPage_GetTrimBox()?;
-        result.extern_FPDFPage_GetArtBox()?;
-        result.extern_FPDFPage_SetMediaBox()?;
-        result.extern_FPDFPage_SetCropBox()?;
-        result.extern_FPDFPage_SetBleedBox()?;
-        result.extern_FPDFPage_SetTrimBox()?;
-        result.extern_FPDFPage_SetArtBox()?;
-        result.extern_FPDFPage_TransFormWithClip()?;
-        result.extern_FPDFPageObj_TransformClipPath()?;
-        result.extern_FPDFPageObj_GetClipPath()?;
-        result.extern_FPDFClipPath_CountPaths()?;
-        result.extern_FPDFClipPath_CountPathSegments()?;
-        result.extern_FPDFClipPath_GetPathSegment()?;
-        result.extern_FPDF_CreateClipPath()?;
-        result.extern_FPDF_DestroyClipPath()?;
-        result.extern_FPDFPage_InsertClipPath()?;
-        result.extern_FPDFPage_HasTransparency()?;
-        result.extern_FPDFPage_GenerateContent()?;
-        result.extern_FPDFBitmap_CreateEx()?;
-        result.extern_FPDFBitmap_Destroy()?;
-        result.extern_FPDFBitmap_GetFormat()?;
-        result.extern_FPDFBitmap_FillRect()?;
-        result.extern_FPDFBitmap_GetBuffer()?;
-        result.extern_FPDFBitmap_GetWidth()?;
-        result.extern_FPDFBitmap_GetHeight()?;
-        result.extern_FPDFBitmap_GetStride()?;
-        result.extern_FPDF_RenderPageBitmap()?;
-        result.extern_FPDF_RenderPageBitmapWithMatrix()?;
-        result.extern_FPDFAnnot_IsSupportedSubtype()?;
-        result.extern_FPDFPage_CreateAnnot()?;
-        result.extern_FPDFPage_GetAnnotCount()?;
-        result.extern_FPDFPage_GetAnnot()?;
-        result.extern_FPDFPage_GetAnnotIndex()?;
-        result.extern_FPDFPage_CloseAnnot()?;
-        result.extern_FPDFPage_RemoveAnnot()?;
-        result.extern_FPDFAnnot_GetSubtype()?;
-        result.extern_FPDFAnnot_IsObjectSupportedSubtype()?;
-        result.extern_FPDFAnnot_UpdateObject()?;
-        result.extern_FPDFAnnot_AddInkStroke()?;
-        result.extern_FPDFAnnot_RemoveInkList()?;
-        result.extern_FPDFAnnot_AppendObject()?;
-        result.extern_FPDFAnnot_GetObjectCount()?;
-        result.extern_FPDFAnnot_GetObject()?;
-        result.extern_FPDFAnnot_RemoveObject()?;
-        result.extern_FPDFAnnot_SetColor()?;
-        result.extern_FPDFAnnot_HasAttachmentPoints()?;
-        result.extern_FPDFAnnot_SetAttachmentPoints()?;
-        result.extern_FPDFAnnot_AppendAttachmentPoints()?;
-        result.extern_FPDFAnnot_CountAttachmentPoints()?;
-        result.extern_FPDFAnnot_GetAttachmentPoints()?;
-        result.extern_FPDFAnnot_SetRect()?;
-        result.extern_FPDFAnnot_GetRect()?;
-        result.extern_FPDFAnnot_GetVertices()?;
-        result.extern_FPDFAnnot_GetInkListCount()?;
-        result.extern_FPDFAnnot_GetInkListPath()?;
-        result.extern_FPDFAnnot_GetLine()?;
-        result.extern_FPDFAnnot_SetBorder()?;
-        result.extern_FPDFAnnot_GetBorder()?;
-        result.extern_FPDFAnnot_HasKey()?;
-        result.extern_FPDFAnnot_GetValueType()?;
-        result.extern_FPDFAnnot_SetStringValue()?;
-        result.extern_FPDFAnnot_GetStringValue()?;
-        result.extern_FPDFAnnot_GetNumberValue()?;
-        result.extern_FPDFAnnot_SetAP()?;
-        result.extern_FPDFAnnot_GetAP()?;
-        result.extern_FPDFAnnot_GetLinkedAnnot()?;
-        result.extern_FPDFAnnot_GetFlags()?;
-        result.extern_FPDFAnnot_SetFlags()?;
-        result.extern_FPDFAnnot_GetFormFieldFlags()?;
-        result.extern_FPDFAnnot_GetFormFieldAtPoint()?;
-        result.extern_FPDFAnnot_GetFormFieldName()?;
-        result.extern_FPDFAnnot_GetFormFieldType()?;
-        result.extern_FPDFAnnot_GetFormFieldValue()?;
-        result.extern_FPDFAnnot_GetOptionCount()?;
-        result.extern_FPDFAnnot_GetOptionLabel()?;
-        result.extern_FPDFAnnot_IsOptionSelected()?;
-        result.extern_FPDFAnnot_GetFontSize()?;
-        result.extern_FPDFAnnot_IsChecked()?;
-        result.extern_FPDFAnnot_SetFocusableSubtypes()?;
-        result.extern_FPDFAnnot_GetFocusableSubtypesCount()?;
-        result.extern_FPDFAnnot_GetFocusableSubtypes()?;
-        result.extern_FPDFAnnot_GetLink()?;
-        result.extern_FPDFAnnot_GetFormControlCount()?;
-        result.extern_FPDFAnnot_GetFormControlIndex()?;
-        result.extern_FPDFAnnot_GetFormFieldExportValue()?;
-        result.extern_FPDFAnnot_SetURI()?;
-        result.extern_FPDFDOC_InitFormFillEnvironment()?;
-        result.extern_FPDFDOC_ExitFormFillEnvironment()?;
-        result.extern_FORM_OnAfterLoadPage()?;
-        result.extern_FORM_OnBeforeClosePage()?;
-        result.extern_FPDFDoc_GetPageMode()?;
-        result.extern_FPDFPage_Flatten()?;
-        result.extern_FPDF_SetFormFieldHighlightColor()?;
-        result.extern_FPDF_SetFormFieldHighlightAlpha()?;
-        result.extern_FPDF_FFLDraw()?;
-        result.extern_FPDFBookmark_GetFirstChild()?;
-        result.extern_FPDFBookmark_GetNextSibling()?;
-        result.extern_FPDFBookmark_GetTitle()?;
-        result.extern_FPDFBookmark_GetCount()?;
-        result.extern_FPDFBookmark_Find()?;
-        result.extern_FPDFBookmark_GetDest()?;
-        result.extern_FPDFBookmark_GetAction()?;
-        result.extern_FPDFAction_GetType()?;
-        result.extern_FPDFAction_GetDest()?;
-        result.extern_FPDFAction_GetFilePath()?;
-        result.extern_FPDFAction_GetURIPath()?;
-        result.extern_FPDFDest_GetDestPageIndex()?;
-        result.extern_FPDFDest_GetView()?;
-        result.extern_FPDFDest_GetLocationInPage()?;
-        result.extern_FPDFLink_GetLinkAtPoint()?;
-        result.extern_FPDFLink_GetLinkZOrderAtPoint()?;
-        result.extern_FPDFLink_GetDest()?;
-        result.extern_FPDFLink_GetAction()?;
-        result.extern_FPDFLink_Enumerate()?;
-        result.extern_FPDFLink_GetAnnot()?;
-        result.extern_FPDFLink_GetAnnotRect()?;
-        result.extern_FPDFLink_CountQuadPoints()?;
-        result.extern_FPDFLink_GetQuadPoints()?;
-        result.extern_FPDF_GetPageAAction()?;
-        result.extern_FPDFText_LoadPage()?;
-        result.extern_FPDFText_ClosePage()?;
-        result.extern_FPDFText_CountChars()?;
-        result.extern_FPDFText_GetUnicode()?;
-        result.extern_FPDFText_GetFontSize()?;
-        result.extern_FPDFText_GetFontInfo()?;
-        result.extern_FPDFText_GetFontWeight()?;
-        result.extern_FPDFText_GetTextRenderMode()?;
-        result.extern_FPDFText_GetFillColor()?;
-        result.extern_FPDFText_GetStrokeColor()?;
-        result.extern_FPDFText_GetCharAngle()?;
-        result.extern_FPDFText_GetCharBox()?;
-        result.extern_FPDFText_GetLooseCharBox()?;
-        result.extern_FPDFText_GetMatrix()?;
-        result.extern_FPDFText_GetCharOrigin()?;
-        result.extern_FPDFText_GetCharIndexAtPos()?;
-        result.extern_FPDFText_GetText()?;
-        result.extern_FPDFText_CountRects()?;
-        result.extern_FPDFText_GetRect()?;
-        result.extern_FPDFText_GetBoundedText()?;
-        result.extern_FPDFText_FindStart()?;
-        result.extern_FPDFText_FindNext()?;
-        result.extern_FPDFText_FindPrev()?;
-        result.extern_FPDFText_GetSchResultIndex()?;
-        result.extern_FPDFText_GetSchCount()?;
-        result.extern_FPDFText_FindClose()?;
-        result.extern_FPDFLink_LoadWebLinks()?;
-        result.extern_FPDFLink_CountWebLinks()?;
-        result.extern_FPDFLink_GetURL()?;
-        result.extern_FPDFLink_CountRects()?;
-        result.extern_FPDFLink_GetRect()?;
-        result.extern_FPDFLink_GetTextRange()?;
-        result.extern_FPDFLink_CloseWebLinks()?;
-        result.extern_FPDFPage_GetDecodedThumbnailData()?;
-        result.extern_FPDFPage_GetRawThumbnailData()?;
-        result.extern_FPDFPage_GetThumbnailAsBitmap()?;
-        result.extern_FPDFFormObj_CountObjects()?;
-        result.extern_FPDFFormObj_GetObject()?;
-        result.extern_FPDFPageObj_CreateTextObj()?;
-        result.extern_FPDFTextObj_GetTextRenderMode()?;
-        result.extern_FPDFTextObj_SetTextRenderMode()?;
-        result.extern_FPDFTextObj_GetText()?;
-        result.extern_FPDFTextObj_GetFont()?;
-        result.extern_FPDFTextObj_GetFontSize()?;
-        result.extern_FPDFPageObj_NewTextObj()?;
-        result.extern_FPDFText_SetText()?;
-        result.extern_FPDFText_SetCharcodes()?;
-        result.extern_FPDFText_LoadFont()?;
-        result.extern_FPDFText_LoadStandardFont()?;
-        result.extern_FPDFFont_Close()?;
-        result.extern_FPDFPath_MoveTo()?;
-        result.extern_FPDFPath_LineTo()?;
-        result.extern_FPDFPath_BezierTo()?;
-        result.extern_FPDFPath_Close()?;
-        result.extern_FPDFPath_SetDrawMode()?;
-        result.extern_FPDFPath_GetDrawMode()?;
-        result.extern_FPDFPage_InsertObject()?;
-        result.extern_FPDFPage_RemoveObject()?;
-        result.extern_FPDFPage_CountObjects()?;
-        result.extern_FPDFPage_GetObject()?;
-        result.extern_FPDFPageObj_Destroy()?;
-        result.extern_FPDFPageObj_HasTransparency()?;
-        result.extern_FPDFPageObj_GetType()?;
-        result.extern_FPDFPageObj_Transform()?;
-        result.extern_FPDFPageObj_GetMatrix()?;
-        result.extern_FPDFPageObj_SetMatrix()?;
-        result.extern_FPDFPageObj_NewImageObj()?;
-        result.extern_FPDFPageObj_CountMarks()?;
-        result.extern_FPDFPageObj_GetMark()?;
-        result.extern_FPDFPageObj_AddMark()?;
-        result.extern_FPDFPageObj_RemoveMark()?;
-        result.extern_FPDFPageObjMark_GetName()?;
-        result.extern_FPDFPageObjMark_CountParams()?;
-        result.extern_FPDFPageObjMark_GetParamKey()?;
-        result.extern_FPDFPageObjMark_GetParamValueType()?;
-        result.extern_FPDFPageObjMark_GetParamIntValue()?;
-        result.extern_FPDFPageObjMark_GetParamStringValue()?;
-        result.extern_FPDFPageObjMark_GetParamBlobValue()?;
-        result.extern_FPDFPageObjMark_SetIntParam()?;
-        result.extern_FPDFPageObjMark_SetStringParam()?;
-        result.extern_FPDFPageObjMark_SetBlobParam()?;
-        result.extern_FPDFPageObjMark_RemoveParam()?;
-        result.extern_FPDFImageObj_LoadJpegFile()?;
-        result.extern_FPDFImageObj_LoadJpegFileInline()?;
-        result.extern_FPDFImageObj_SetMatrix()?;
-        result.extern_FPDFImageObj_SetBitmap()?;
-        result.extern_FPDFImageObj_GetBitmap()?;
-        result.extern_FPDFImageObj_GetRenderedBitmap()?;
-        result.extern_FPDFImageObj_GetImageDataDecoded()?;
-        result.extern_FPDFImageObj_GetImageDataRaw()?;
-        result.extern_FPDFImageObj_GetImageFilterCount()?;
-        result.extern_FPDFImageObj_GetImageFilter()?;
-        result.extern_FPDFImageObj_GetImageMetadata()?;
-        result.extern_FPDFPageObj_CreateNewPath()?;
-        result.extern_FPDFPageObj_CreateNewRect()?;
-        result.extern_FPDFPageObj_GetBounds()?;
-        result.extern_FPDFPageObj_SetBlendMode()?;
-        result.extern_FPDFPageObj_SetStrokeColor()?;
-        result.extern_FPDFPageObj_GetStrokeColor()?;
-        result.extern_FPDFPageObj_SetStrokeWidth()?;
-        result.extern_FPDFPageObj_GetStrokeWidth()?;
-        result.extern_FPDFPageObj_GetLineJoin()?;
-        result.extern_FPDFPageObj_SetLineJoin()?;
-        result.extern_FPDFPageObj_GetLineCap()?;
-        result.extern_FPDFPageObj_SetLineCap()?;
-        result.extern_FPDFPageObj_SetFillColor()?;
-        result.extern_FPDFPageObj_GetFillColor()?;
-        result.extern_FPDFPageObj_GetDashPhase()?;
-        result.extern_FPDFPageObj_SetDashPhase()?;
-        result.extern_FPDFPageObj_GetDashCount()?;
-        result.extern_FPDFPageObj_GetDashArray()?;
-        result.extern_FPDFPageObj_SetDashArray()?;
-        result.extern_FPDFPath_CountSegments()?;
-        result.extern_FPDFPath_GetPathSegment()?;
-        result.extern_FPDFPathSegment_GetPoint()?;
-        result.extern_FPDFPathSegment_GetType()?;
-        result.extern_FPDFPathSegment_GetClose()?;
-        result.extern_FPDFFont_GetFontName()?;
-        result.extern_FPDFFont_GetFlags()?;
-        result.extern_FPDFFont_GetWeight()?;
-        result.extern_FPDFFont_GetItalicAngle()?;
-        result.extern_FPDFFont_GetAscent()?;
-        result.extern_FPDFFont_GetDescent()?;
-        result.extern_FPDFFont_GetGlyphWidth()?;
-        result.extern_FPDFFont_GetGlyphPath()?;
-        result.extern_FPDFGlyphPath_CountGlyphSegments()?;
-        result.extern_FPDFGlyphPath_GetGlyphPathSegment()?;
-        result.extern_FPDF_VIEWERREF_GetPrintScaling()?;
-        result.extern_FPDF_VIEWERREF_GetNumCopies()?;
-        result.extern_FPDF_VIEWERREF_GetPrintPageRange()?;
-        result.extern_FPDF_VIEWERREF_GetPrintPageRangeCount()?;
-        result.extern_FPDF_VIEWERREF_GetPrintPageRangeElement()?;
-        result.extern_FPDF_VIEWERREF_GetDuplex()?;
-        result.extern_FPDF_VIEWERREF_GetName()?;
-        result.extern_FPDFDoc_GetAttachmentCount()?;
-        result.extern_FPDFDoc_AddAttachment()?;
-        result.extern_FPDFDoc_GetAttachment()?;
-        result.extern_FPDFDoc_DeleteAttachment()?;
-        result.extern_FPDFAttachment_GetName()?;
-        result.extern_FPDFAttachment_HasKey()?;
-        result.extern_FPDFAttachment_GetValueType()?;
-        result.extern_FPDFAttachment_SetStringValue()?;
-        result.extern_FPDFAttachment_GetStringValue()?;
-        result.extern_FPDFAttachment_SetFile()?;
-        result.extern_FPDFAttachment_GetFile()?;
-        result.extern_FPDFCatalog_IsTagged()?;
+        let result = unsafe {
+            DynamicPdfiumBindings {
+                extern_FPDF_InitLibrary: *(library.get(b"FPDF_InitLibrary\0")?),
+                extern_FPDF_DestroyLibrary: *(library.get(b"FPDF_DestroyLibrary\0")?),
+                extern_FPDF_GetLastError: *(library.get(b"FPDF_GetLastError\0")?),
+                extern_FPDF_CreateNewDocument: *(library.get(b"FPDF_CreateNewDocument\0")?),
+                extern_FPDF_LoadDocument: *(library.get(b"FPDF_LoadDocument\0")?),
+                extern_FPDF_LoadMemDocument64: *(library.get(b"FPDF_LoadMemDocument64\0")?),
+                extern_FPDF_LoadCustomDocument: *(library.get(b"FPDF_LoadCustomDocument\0")?),
+                extern_FPDF_SaveAsCopy: *(library.get(b"FPDF_SaveAsCopy\0")?),
+                extern_FPDF_SaveWithVersion: *(library.get(b"FPDF_SaveWithVersion\0")?),
+                extern_FPDF_CloseDocument: *(library.get(b"FPDF_CloseDocument\0")?),
+                extern_FPDF_DeviceToPage: *(library.get(b"FPDF_DeviceToPage\0")?),
+                extern_FPDF_PageToDevice: *(library.get(b"FPDF_PageToDevice\0")?),
+                extern_FPDF_GetFileVersion: *(library.get(b"FPDF_GetFileVersion\0")?),
+                extern_FPDF_GetFileIdentifier: *(library.get(b"FPDF_GetFileIdentifier\0")?),
+                extern_FPDF_GetMetaText: *(library.get(b"FPDF_GetMetaText\0")?),
+                extern_FPDF_GetDocPermissions: *(library.get(b"FPDF_GetDocPermissions\0")?),
+                extern_FPDF_GetSecurityHandlerRevision: *(library
+                    .get(b"FPDF_GetSecurityHandlerRevision\0")?),
+                extern_FPDF_GetPageCount: *(library.get(b"FPDF_GetPageCount\0")?),
+                extern_FPDF_LoadPage: *(library.get(b"FPDF_LoadPage\0")?),
+                extern_FPDF_ClosePage: *(library.get(b"FPDF_ClosePage\0")?),
+                extern_FPDF_ImportPagesByIndex: *(library.get(b"FPDF_ImportPagesByIndex\0")?),
+                extern_FPDF_ImportPages: *(library.get(b"FPDF_ImportPages\0")?),
+                extern_FPDF_ImportNPagesToOne: *(library.get(b"FPDF_ImportNPagesToOne\0")?),
+                extern_FPDF_GetPageLabel: *(library.get(b"FPDF_GetPageLabel\0")?),
+                extern_FPDF_GetPageBoundingBox: *(library.get(b"FPDF_GetPageBoundingBox\0")?),
+                extern_FPDF_GetPageSizeByIndexF: *(library.get(b"FPDF_GetPageSizeByIndexF\0")?),
+                extern_FPDF_GetPageWidthF: *(library.get(b"FPDF_GetPageWidthF\0")?),
+                extern_FPDF_GetPageHeightF: *(library.get(b"FPDF_GetPageHeightF\0")?),
+                extern_FPDFText_GetCharIndexFromTextIndex: *(library
+                    .get(b"FPDFText_GetCharIndexFromTextIndex\0")?),
+                extern_FPDFText_GetTextIndexFromCharIndex: *(library
+                    .get(b"FPDFText_GetTextIndexFromCharIndex\0")?),
+                extern_FPDF_GetSignatureCount: *(library.get(b"FPDF_GetSignatureCount\0")?),
+                extern_FPDF_GetSignatureObject: *(library.get(b"FPDF_GetSignatureObject\0")?),
+                extern_FPDFSignatureObj_GetContents: *(library
+                    .get(b"FPDFSignatureObj_GetContents\0")?),
+                extern_FPDFSignatureObj_GetByteRange: *(library
+                    .get(b"FPDFSignatureObj_GetByteRange\0")?),
+                extern_FPDFSignatureObj_GetSubFilter: *(library
+                    .get(b"FPDFSignatureObj_GetSubFilter\0")?),
+                extern_FPDFSignatureObj_GetReason: *(library
+                    .get(b"FPDFSignatureObj_GetReason\0")?),
+                extern_FPDFSignatureObj_GetTime: *(library.get(b"FPDFSignatureObj_GetTime\0")?),
+                extern_FPDFSignatureObj_GetDocMDPPermission: *(library
+                    .get(b"FPDFSignatureObj_GetDocMDPPermission\0")?),
+                extern_FPDF_StructTree_GetForPage: *(library
+                    .get(b"FPDF_StructTree_GetForPage\0")?),
+                extern_FPDF_StructTree_Close: *(library.get(b"FPDF_StructTree_Close\0")?),
+                extern_FPDF_StructTree_CountChildren: *(library
+                    .get(b"FPDF_StructTree_CountChildren\0")?),
+                extern_FPDF_StructTree_GetChildAtIndex: *(library
+                    .get(b"FPDF_StructTree_GetChildAtIndex\0")?),
+                extern_FPDF_StructElement_GetAltText: *(library
+                    .get(b"FPDF_StructElement_GetAltText\0")?),
+                extern_FPDF_StructElement_GetID: *(library.get(b"FPDF_StructElement_GetID\0")?),
+                extern_FPDF_StructElement_GetLang: *(library
+                    .get(b"FPDF_StructElement_GetLang\0")?),
+                extern_FPDF_StructElement_GetStringAttribute: *(library
+                    .get(b"FPDF_StructElement_GetStringAttribute\0")?),
+                extern_FPDF_StructElement_GetMarkedContentID: *(library
+                    .get(b"FPDF_StructElement_GetMarkedContentID\0")?),
+                extern_FPDF_StructElement_GetType: *(library
+                    .get(b"FPDF_StructElement_GetType\0")?),
+                extern_FPDF_StructElement_GetTitle: *(library
+                    .get(b"FPDF_StructElement_GetTitle\0")?),
+                extern_FPDF_StructElement_CountChildren: *(library
+                    .get(b"FPDF_StructElement_CountChildren\0")?),
+                extern_FPDF_StructElement_GetChildAtIndex: *(library
+                    .get(b"FPDF_StructElement_GetChildAtIndex\0")?),
+                extern_FPDFPage_New: *(library.get(b"FPDFPage_New\0")?),
+                extern_FPDFPage_Delete: *(library.get(b"FPDFPage_Delete\0")?),
+                extern_FPDFPage_GetRotation: *(library.get(b"FPDFPage_GetRotation\0")?),
+                extern_FPDFPage_SetRotation: *(library.get(b"FPDFPage_SetRotation\0")?),
+                extern_FPDFPage_GetMediaBox: *(library.get(b"FPDFPage_GetMediaBox\0")?),
+                extern_FPDFPage_GetCropBox: *(library.get(b"FPDFPage_GetCropBox\0")?),
+                extern_FPDFPage_GetBleedBox: *(library.get(b"FPDFPage_GetBleedBox\0")?),
+                extern_FPDFPage_GetTrimBox: *(library.get(b"FPDFPage_GetTrimBox\0")?),
+                extern_FPDFPage_GetArtBox: *(library.get(b"FPDFPage_GetArtBox\0")?),
+                extern_FPDFPage_SetMediaBox: *(library.get(b"FPDFPage_SetMediaBox\0")?),
+                extern_FPDFPage_SetCropBox: *(library.get(b"FPDFPage_SetCropBox\0")?),
+                extern_FPDFPage_SetBleedBox: *(library.get(b"FPDFPage_SetBleedBox\0")?),
+                extern_FPDFPage_SetTrimBox: *(library.get(b"FPDFPage_SetTrimBox\0")?),
+                extern_FPDFPage_SetArtBox: *(library.get(b"FPDFPage_SetArtBox\0")?),
+                extern_FPDFPage_TransFormWithClip: *(library
+                    .get(b"FPDFPage_TransFormWithClip\0")?),
+                extern_FPDFPageObj_TransformClipPath: *(library
+                    .get(b"FPDFPageObj_TransformClipPath\0")?),
+                extern_FPDFPageObj_GetClipPath: *(library.get(b"FPDFPageObj_GetClipPath\0")?),
+                extern_FPDFClipPath_CountPaths: *(library.get(b"FPDFClipPath_CountPaths\0")?),
+                extern_FPDFClipPath_CountPathSegments: *(library
+                    .get(b"FPDFClipPath_CountPathSegments\0")?),
+                extern_FPDFClipPath_GetPathSegment: *(library
+                    .get(b"FPDFClipPath_GetPathSegment\0")?),
+                extern_FPDF_CreateClipPath: *(library.get(b"FPDF_CreateClipPath\0")?),
+                extern_FPDF_DestroyClipPath: *(library.get(b"FPDF_DestroyClipPath\0")?),
+                extern_FPDFPage_InsertClipPath: *(library.get(b"FPDFPage_InsertClipPath\0")?),
+                extern_FPDFPage_HasTransparency: *(library.get(b"FPDFPage_HasTransparency\0")?),
+                extern_FPDFPage_GenerateContent: *(library.get(b"FPDFPage_GenerateContent\0")?),
+                extern_FPDFBitmap_CreateEx: *(library.get(b"FPDFBitmap_CreateEx\0")?),
+                extern_FPDFBitmap_Destroy: *(library.get(b"FPDFBitmap_Destroy\0")?),
+                extern_FPDFBitmap_GetFormat: *(library.get(b"FPDFBitmap_GetFormat\0")?),
+                extern_FPDFBitmap_FillRect: *(library.get(b"FPDFBitmap_FillRect\0")?),
+                extern_FPDFBitmap_GetBuffer: *(library.get(b"FPDFBitmap_GetBuffer\0")?),
+                extern_FPDFBitmap_GetWidth: *(library.get(b"FPDFBitmap_GetWidth\0")?),
+                extern_FPDFBitmap_GetHeight: *(library.get(b"FPDFBitmap_GetHeight\0")?),
+                extern_FPDFBitmap_GetStride: *(library.get(b"FPDFBitmap_GetStride\0")?),
+                extern_FPDF_RenderPageBitmap: *(library.get(b"FPDF_RenderPageBitmap\0")?),
+                extern_FPDF_RenderPageBitmapWithMatrix: *(library
+                    .get(b"FPDF_RenderPageBitmapWithMatrix\0")?),
+                extern_FPDFAnnot_IsSupportedSubtype: *(library
+                    .get(b"FPDFAnnot_IsSupportedSubtype\0")?),
+                extern_FPDFPage_CreateAnnot: *(library.get(b"FPDFPage_CreateAnnot\0")?),
+                extern_FPDFPage_GetAnnotCount: *(library.get(b"FPDFPage_GetAnnotCount\0")?),
+                extern_FPDFPage_GetAnnot: *(library.get(b"FPDFPage_GetAnnot\0")?),
+                extern_FPDFPage_GetAnnotIndex: *(library.get(b"FPDFPage_GetAnnotIndex\0")?),
+                extern_FPDFPage_CloseAnnot: *(library.get(b"FPDFPage_CloseAnnot\0")?),
+                extern_FPDFPage_RemoveAnnot: *(library.get(b"FPDFPage_RemoveAnnot\0")?),
+                extern_FPDFAnnot_GetSubtype: *(library.get(b"FPDFAnnot_GetSubtype\0")?),
+                extern_FPDFAnnot_IsObjectSupportedSubtype: *(library
+                    .get(b"FPDFAnnot_IsObjectSupportedSubtype\0")?),
+                extern_FPDFAnnot_UpdateObject: *(library.get(b"FPDFAnnot_UpdateObject\0")?),
+                extern_FPDFAnnot_AddInkStroke: *(library.get(b"FPDFAnnot_AddInkStroke\0")?),
+                extern_FPDFAnnot_RemoveInkList: *(library.get(b"FPDFAnnot_RemoveInkList\0")?),
+                extern_FPDFAnnot_AppendObject: *(library.get(b"FPDFAnnot_AppendObject\0")?),
+                extern_FPDFAnnot_GetObjectCount: *(library.get(b"FPDFAnnot_GetObjectCount\0")?),
+                extern_FPDFAnnot_GetObject: *(library.get(b"FPDFAnnot_GetObject\0")?),
+                extern_FPDFAnnot_RemoveObject: *(library.get(b"FPDFAnnot_RemoveObject\0")?),
+                extern_FPDFAnnot_SetColor: *(library.get(b"FPDFAnnot_SetColor\0")?),
+                extern_FPDFAnnot_GetColor: *(library.get(b"FPDFAnnot_GetColor\0")?),
+                extern_FPDFAnnot_HasAttachmentPoints: *(library
+                    .get(b"FPDFAnnot_HasAttachmentPoints\0")?),
+                extern_FPDFAnnot_SetAttachmentPoints: *(library
+                    .get(b"FPDFAnnot_SetAttachmentPoints\0")?),
+                extern_FPDFAnnot_AppendAttachmentPoints: *(library
+                    .get(b"FPDFAnnot_AppendAttachmentPoints\0")?),
+                extern_FPDFAnnot_CountAttachmentPoints: *(library
+                    .get(b"FPDFAnnot_CountAttachmentPoints\0")?),
+                extern_FPDFAnnot_GetAttachmentPoints: *(library
+                    .get(b"FPDFAnnot_GetAttachmentPoints\0")?),
+                extern_FPDFAnnot_SetRect: *(library.get(b"FPDFAnnot_SetRect\0")?),
+                extern_FPDFAnnot_GetRect: *(library.get(b"FPDFAnnot_GetRect\0")?),
+                extern_FPDFAnnot_GetVertices: *(library.get(b"FPDFAnnot_GetVertices\0")?),
+                extern_FPDFAnnot_GetInkListCount: *(library.get(b"FPDFAnnot_GetInkListCount\0")?),
+                extern_FPDFAnnot_GetInkListPath: *(library.get(b"FPDFAnnot_GetInkListPath\0")?),
+                extern_FPDFAnnot_GetLine: *(library.get(b"FPDFAnnot_GetLine\0")?),
+                extern_FPDFAnnot_SetBorder: *(library.get(b"FPDFAnnot_SetBorder\0")?),
+                extern_FPDFAnnot_GetBorder: *(library.get(b"FPDFAnnot_GetBorder\0")?),
+                extern_FPDFAnnot_HasKey: *(library.get(b"FPDFAnnot_HasKey\0")?),
+                extern_FPDFAnnot_GetValueType: *(library.get(b"FPDFAnnot_GetValueType\0")?),
+                extern_FPDFAnnot_SetStringValue: *(library.get(b"FPDFAnnot_SetStringValue\0")?),
+                extern_FPDFAnnot_GetStringValue: *(library.get(b"FPDFAnnot_GetStringValue\0")?),
+                extern_FPDFAnnot_GetNumberValue: *(library.get(b"FPDFAnnot_GetNumberValue\0")?),
+                extern_FPDFAnnot_SetAP: *(library.get(b"FPDFAnnot_SetAP\0")?),
+                extern_FPDFAnnot_GetAP: *(library.get(b"FPDFAnnot_GetAP\0")?),
+                extern_FPDFAnnot_GetLinkedAnnot: *(library.get(b"FPDFAnnot_GetLinkedAnnot\0")?),
+                extern_FPDFAnnot_GetFlags: *(library.get(b"FPDFAnnot_GetFlags\0")?),
+                extern_FPDFAnnot_SetFlags: *(library.get(b"FPDFAnnot_SetFlags\0")?),
+                extern_FPDFAnnot_GetFormFieldFlags: *(library
+                    .get(b"FPDFAnnot_GetFormFieldFlags\0")?),
+                extern_FPDFAnnot_GetFormFieldAtPoint: *(library
+                    .get(b"FPDFAnnot_GetFormFieldAtPoint\0")?),
+                extern_FPDFAnnot_GetFormFieldName: *(library
+                    .get(b"FPDFAnnot_GetFormFieldName\0")?),
+                extern_FPDFAnnot_GetFormFieldType: *(library
+                    .get(b"FPDFAnnot_GetFormFieldType\0")?),
+                extern_FPDFAnnot_GetFormFieldValue: *(library
+                    .get(b"FPDFAnnot_GetFormFieldValue\0")?),
+                extern_FPDFAnnot_GetOptionCount: *(library.get(b"FPDFAnnot_GetOptionCount\0")?),
+                extern_FPDFAnnot_GetOptionLabel: *(library.get(b"FPDFAnnot_GetOptionLabel\0")?),
+                extern_FPDFAnnot_IsOptionSelected: *(library
+                    .get(b"FPDFAnnot_IsOptionSelected\0")?),
+                extern_FPDFAnnot_GetFontSize: *(library.get(b"FPDFAnnot_GetFontSize\0")?),
+                extern_FPDFAnnot_IsChecked: *(library.get(b"FPDFAnnot_IsChecked\0")?),
+                extern_FPDFAnnot_SetFocusableSubtypes: *(library
+                    .get(b"FPDFAnnot_SetFocusableSubtypes\0")?),
+                extern_FPDFAnnot_GetFocusableSubtypesCount: *(library
+                    .get(b"FPDFAnnot_GetFocusableSubtypesCount\0")?),
+                extern_FPDFAnnot_GetFocusableSubtypes: *(library
+                    .get(b"FPDFAnnot_GetFocusableSubtypes\0")?),
+                extern_FPDFAnnot_GetLink: *(library.get(b"FPDFAnnot_GetLink\0")?),
+                extern_FPDFAnnot_GetFormControlCount: *(library
+                    .get(b"FPDFAnnot_GetFormControlCount\0")?),
+                extern_FPDFAnnot_GetFormControlIndex: *(library
+                    .get(b"FPDFAnnot_GetFormControlIndex\0")?),
+                extern_FPDFAnnot_GetFormFieldExportValue: *(library
+                    .get(b"FPDFAnnot_GetFormFieldExportValue\0")?),
+                extern_FPDFAnnot_SetURI: *(library.get(b"FPDFAnnot_SetURI\0")?),
+                extern_FPDFDOC_InitFormFillEnvironment: *(library
+                    .get(b"FPDFDOC_InitFormFillEnvironment\0")?),
+                extern_FPDFDOC_ExitFormFillEnvironment: *(library
+                    .get(b"FPDFDOC_ExitFormFillEnvironment\0")?),
+                extern_FORM_OnAfterLoadPage: *(library.get(b"FORM_OnAfterLoadPage\0")?),
+                extern_FORM_OnBeforeClosePage: *(library.get(b"FORM_OnBeforeClosePage\0")?),
+                extern_FPDFDoc_GetPageMode: *(library.get(b"FPDFDoc_GetPageMode\0")?),
+                extern_FPDFPage_Flatten: *(library.get(b"FPDFPage_Flatten\0")?),
+                extern_FPDF_SetFormFieldHighlightColor: *(library
+                    .get(b"FPDF_SetFormFieldHighlightColor\0")?),
+                extern_FPDF_SetFormFieldHighlightAlpha: *(library
+                    .get(b"FPDF_SetFormFieldHighlightAlpha\0")?),
+                extern_FPDF_FFLDraw: *(library.get(b"FPDF_FFLDraw\0")?),
+                extern_FPDF_GetFormType: *(library.get(b"FPDF_GetFormType\0")?),
+                extern_FPDFBookmark_GetFirstChild: *(library
+                    .get(b"FPDFBookmark_GetFirstChild\0")?),
+                extern_FPDFBookmark_GetNextSibling: *(library
+                    .get(b"FPDFBookmark_GetNextSibling\0")?),
+                extern_FPDFBookmark_GetTitle: *(library.get(b"FPDFBookmark_GetTitle\0")?),
+                extern_FPDFBookmark_GetCount: *(library.get(b"FPDFBookmark_GetCount\0")?),
+                extern_FPDFBookmark_Find: *(library.get(b"FPDFBookmark_Find\0")?),
+                extern_FPDFBookmark_GetDest: *(library.get(b"FPDFBookmark_GetDest\0")?),
+                extern_FPDFBookmark_GetAction: *(library.get(b"FPDFBookmark_GetAction\0")?),
+                extern_FPDFAction_GetType: *(library.get(b"FPDFAction_GetType\0")?),
+                extern_FPDFAction_GetDest: *(library.get(b"FPDFAction_GetDest\0")?),
+                extern_FPDFAction_GetFilePath: *(library.get(b"FPDFAction_GetFilePath\0")?),
+                extern_FPDFAction_GetURIPath: *(library.get(b"FPDFAction_GetURIPath\0")?),
+                extern_FPDFDest_GetDestPageIndex: *(library.get(b"FPDFDest_GetDestPageIndex\0")?),
+                extern_FPDFDest_GetView: *(library.get(b"FPDFDest_GetView\0")?),
+                extern_FPDFDest_GetLocationInPage: *(library
+                    .get(b"FPDFDest_GetLocationInPage\0")?),
+                extern_FPDFLink_GetLinkAtPoint: *(library.get(b"FPDFLink_GetLinkAtPoint\0")?),
+                extern_FPDFLink_GetLinkZOrderAtPoint: *(library
+                    .get(b"FPDFLink_GetLinkZOrderAtPoint\0")?),
+                extern_FPDFLink_GetDest: *(library.get(b"FPDFLink_GetDest\0")?),
+                extern_FPDFLink_GetAction: *(library.get(b"FPDFLink_GetAction\0")?),
+                extern_FPDFLink_Enumerate: *(library.get(b"FPDFLink_Enumerate\0")?),
+                extern_FPDFLink_GetAnnot: *(library.get(b"FPDFLink_GetAnnot\0")?),
+                extern_FPDFLink_GetAnnotRect: *(library.get(b"FPDFLink_GetAnnotRect\0")?),
+                extern_FPDFLink_CountQuadPoints: *(library.get(b"FPDFLink_CountQuadPoints\0")?),
+                extern_FPDFLink_GetQuadPoints: *(library.get(b"FPDFLink_GetQuadPoints\0")?),
+                extern_FPDF_GetPageAAction: *(library.get(b"FPDF_GetPageAAction\0")?),
+                extern_FPDFText_LoadPage: *(library.get(b"FPDFText_LoadPage\0")?),
+                extern_FPDFText_ClosePage: *(library.get(b"FPDFText_ClosePage\0")?),
+                extern_FPDFText_CountChars: *(library.get(b"FPDFText_CountChars\0")?),
+                extern_FPDFText_GetUnicode: *(library.get(b"FPDFText_GetUnicode\0")?),
+                extern_FPDFText_GetFontSize: *(library.get(b"FPDFText_GetFontSize\0")?),
+                extern_FPDFText_GetFontInfo: *(library.get(b"FPDFText_GetFontInfo\0")?),
+                extern_FPDFText_GetFontWeight: *(library.get(b"FPDFText_GetFontWeight\0")?),
+                extern_FPDFText_GetTextRenderMode: *(library
+                    .get(b"FPDFText_GetTextRenderMode\0")?),
+                extern_FPDFText_GetFillColor: *(library.get(b"FPDFText_GetFillColor\0")?),
+                extern_FPDFText_GetStrokeColor: *(library.get(b"FPDFText_GetStrokeColor\0")?),
+                extern_FPDFText_GetCharAngle: *(library.get(b"FPDFText_GetCharAngle\0")?),
+                extern_FPDFText_GetCharBox: *(library.get(b"FPDFText_GetCharBox\0")?),
+                extern_FPDFText_GetLooseCharBox: *(library.get(b"FPDFText_GetLooseCharBox\0")?),
+                extern_FPDFText_GetMatrix: *(library.get(b"FPDFText_GetMatrix\0")?),
+                extern_FPDFText_GetCharOrigin: *(library.get(b"FPDFText_GetCharOrigin\0")?),
+                extern_FPDFText_GetCharIndexAtPos: *(library
+                    .get(b"FPDFText_GetCharIndexAtPos\0")?),
+                extern_FPDFText_GetText: *(library.get(b"FPDFText_GetText\0")?),
+                extern_FPDFText_CountRects: *(library.get(b"FPDFText_CountRects\0")?),
+                extern_FPDFText_GetRect: *(library.get(b"FPDFText_GetRect\0")?),
+                extern_FPDFText_GetBoundedText: *(library.get(b"FPDFText_GetBoundedText\0")?),
+                extern_FPDFText_FindStart: *(library.get(b"FPDFText_FindStart\0")?),
+                extern_FPDFText_FindNext: *(library.get(b"FPDFText_FindNext\0")?),
+                extern_FPDFText_FindPrev: *(library.get(b"FPDFText_FindPrev\0")?),
+                extern_FPDFText_GetSchResultIndex: *(library
+                    .get(b"FPDFText_GetSchResultIndex\0")?),
+                extern_FPDFText_GetSchCount: *(library.get(b"FPDFText_GetSchCount\0")?),
+                extern_FPDFText_FindClose: *(library.get(b"FPDFText_FindClose\0")?),
+                extern_FPDFLink_LoadWebLinks: *(library.get(b"FPDFLink_LoadWebLinks\0")?),
+                extern_FPDFLink_CountWebLinks: *(library.get(b"FPDFLink_CountWebLinks\0")?),
+                extern_FPDFLink_GetURL: *(library.get(b"FPDFLink_GetURL\0")?),
+                extern_FPDFLink_CountRects: *(library.get(b"FPDFLink_CountRects\0")?),
+                extern_FPDFLink_GetRect: *(library.get(b"FPDFLink_GetRect\0")?),
+                extern_FPDFLink_GetTextRange: *(library.get(b"FPDFLink_GetTextRange\0")?),
+                extern_FPDFLink_CloseWebLinks: *(library.get(b"FPDFLink_CloseWebLinks\0")?),
+                extern_FPDFPage_GetDecodedThumbnailData: *(library
+                    .get(b"FPDFPage_GetDecodedThumbnailData\0")?),
+                extern_FPDFPage_GetRawThumbnailData: *(library
+                    .get(b"FPDFPage_GetRawThumbnailData\0")?),
+                extern_FPDFPage_GetThumbnailAsBitmap: *(library
+                    .get(b"FPDFPage_GetThumbnailAsBitmap\0")?),
+                extern_FPDFFormObj_CountObjects: *(library.get(b"FPDFFormObj_CountObjects\0")?),
+                extern_FPDFFormObj_GetObject: *(library.get(b"FPDFFormObj_GetObject\0")?),
+                extern_FPDFPageObj_CreateTextObj: *(library.get(b"FPDFPageObj_CreateTextObj\0")?),
+                extern_FPDFTextObj_GetTextRenderMode: *(library
+                    .get(b"FPDFTextObj_GetTextRenderMode\0")?),
+                extern_FPDFTextObj_SetTextRenderMode: *(library
+                    .get(b"FPDFTextObj_SetTextRenderMode\0")?),
+                extern_FPDFTextObj_GetText: *(library.get(b"FPDFTextObj_GetText\0")?),
+                extern_FPDFTextObj_GetFont: *(library.get(b"FPDFTextObj_GetFont\0")?),
+                extern_FPDFTextObj_GetFontSize: *(library.get(b"FPDFTextObj_GetFontSize\0")?),
+                extern_FPDFPageObj_NewTextObj: *(library.get(b"FPDFPageObj_NewTextObj\0")?),
+                extern_FPDFText_SetText: *(library.get(b"FPDFText_SetText\0")?),
+                extern_FPDFText_SetCharcodes: *(library.get(b"FPDFText_SetCharcodes\0")?),
+                extern_FPDFText_LoadFont: *(library.get(b"FPDFText_LoadFont\0")?),
+                extern_FPDFText_LoadStandardFont: *(library.get(b"FPDFText_LoadStandardFont\0")?),
+                extern_FPDFFont_Close: *(library.get(b"FPDFFont_Close\0")?),
+                extern_FPDFPath_MoveTo: *(library.get(b"FPDFPath_MoveTo\0")?),
+                extern_FPDFPath_LineTo: *(library.get(b"FPDFPath_LineTo\0")?),
+                extern_FPDFPath_BezierTo: *(library.get(b"FPDFPath_BezierTo\0")?),
+                extern_FPDFPath_Close: *(library.get(b"FPDFPath_Close\0")?),
+                extern_FPDFPath_SetDrawMode: *(library.get(b"FPDFPath_SetDrawMode\0")?),
+                extern_FPDFPath_GetDrawMode: *(library.get(b"FPDFPath_GetDrawMode\0")?),
+                extern_FPDFPage_InsertObject: *(library.get(b"FPDFPage_InsertObject\0")?),
+                extern_FPDFPage_RemoveObject: *(library.get(b"FPDFPage_RemoveObject\0")?),
+                extern_FPDFPage_CountObjects: *(library.get(b"FPDFPage_CountObjects\0")?),
+                extern_FPDFPage_GetObject: *(library.get(b"FPDFPage_GetObject\0")?),
+                extern_FPDFPageObj_Destroy: *(library.get(b"FPDFPageObj_Destroy\0")?),
+                extern_FPDFPageObj_HasTransparency: *(library
+                    .get(b"FPDFPageObj_HasTransparency\0")?),
+                extern_FPDFPageObj_GetType: *(library.get(b"FPDFPageObj_GetType\0")?),
+                extern_FPDFPageObj_Transform: *(library.get(b"FPDFPageObj_Transform\0")?),
+                extern_FPDFPageObj_GetMatrix: *(library.get(b"FPDFPageObj_GetMatrix\0")?),
+                extern_FPDFPageObj_SetMatrix: *(library.get(b"FPDFPageObj_SetMatrix\0")?),
+                extern_FPDFPageObj_NewImageObj: *(library.get(b"FPDFPageObj_NewImageObj\0")?),
+                extern_FPDFPageObj_CountMarks: *(library.get(b"FPDFPageObj_CountMarks\0")?),
+                extern_FPDFPageObj_GetMark: *(library.get(b"FPDFPageObj_GetMark\0")?),
+                extern_FPDFPageObj_AddMark: *(library.get(b"FPDFPageObj_AddMark\0")?),
+                extern_FPDFPageObj_RemoveMark: *(library.get(b"FPDFPageObj_RemoveMark\0")?),
+                extern_FPDFPageObjMark_GetName: *(library.get(b"FPDFPageObjMark_GetName\0")?),
+                extern_FPDFPageObjMark_CountParams: *(library
+                    .get(b"FPDFPageObjMark_CountParams\0")?),
+                extern_FPDFPageObjMark_GetParamKey: *(library
+                    .get(b"FPDFPageObjMark_GetParamKey\0")?),
+                extern_FPDFPageObjMark_GetParamValueType: *(library
+                    .get(b"FPDFPageObjMark_GetParamValueType\0")?),
+                extern_FPDFPageObjMark_GetParamIntValue: *(library
+                    .get(b"FPDFPageObjMark_GetParamIntValue\0")?),
+                extern_FPDFPageObjMark_GetParamStringValue: *(library
+                    .get(b"FPDFPageObjMark_GetParamStringValue\0")?),
+                extern_FPDFPageObjMark_GetParamBlobValue: *(library
+                    .get(b"FPDFPageObjMark_GetParamBlobValue\0")?),
+                extern_FPDFPageObjMark_SetIntParam: *(library
+                    .get(b"FPDFPageObjMark_SetIntParam\0")?),
+                extern_FPDFPageObjMark_SetStringParam: *(library
+                    .get(b"FPDFPageObjMark_SetStringParam\0")?),
+                extern_FPDFPageObjMark_SetBlobParam: *(library
+                    .get(b"FPDFPageObjMark_SetBlobParam\0")?),
+                extern_FPDFPageObjMark_RemoveParam: *(library
+                    .get(b"FPDFPageObjMark_RemoveParam\0")?),
+                extern_FPDFImageObj_LoadJpegFile: *(library.get(b"FPDFImageObj_LoadJpegFile\0")?),
+                extern_FPDFImageObj_LoadJpegFileInline: *(library
+                    .get(b"FPDFImageObj_LoadJpegFileInline\0")?),
+                extern_FPDFImageObj_SetMatrix: *(library.get(b"FPDFImageObj_SetMatrix\0")?),
+                extern_FPDFImageObj_SetBitmap: *(library.get(b"FPDFImageObj_SetBitmap\0")?),
+                extern_FPDFImageObj_GetBitmap: *(library.get(b"FPDFImageObj_GetBitmap\0")?),
+                extern_FPDFImageObj_GetRenderedBitmap: *(library
+                    .get(b"FPDFImageObj_GetRenderedBitmap\0")?),
+                extern_FPDFImageObj_GetImageDataDecoded: *(library
+                    .get(b"FPDFImageObj_GetImageDataDecoded\0")?),
+                extern_FPDFImageObj_GetImageDataRaw: *(library
+                    .get(b"FPDFImageObj_GetImageDataRaw\0")?),
+                extern_FPDFImageObj_GetImageFilterCount: *(library
+                    .get(b"FPDFImageObj_GetImageFilterCount\0")?),
+                extern_FPDFImageObj_GetImageFilter: *(library
+                    .get(b"FPDFImageObj_GetImageFilter\0")?),
+                extern_FPDFImageObj_GetImageMetadata: *(library
+                    .get(b"FPDFImageObj_GetImageMetadata\0")?),
+                extern_FPDFPageObj_CreateNewPath: *(library.get(b"FPDFPageObj_CreateNewPath\0")?),
+                extern_FPDFPageObj_CreateNewRect: *(library.get(b"FPDFPageObj_CreateNewRect\0")?),
+                extern_FPDFPageObj_GetBounds: *(library.get(b"FPDFPageObj_GetBounds\0")?),
+                extern_FPDFPageObj_SetBlendMode: *(library.get(b"FPDFPageObj_SetBlendMode\0")?),
+                extern_FPDFPageObj_SetStrokeColor: *(library
+                    .get(b"FPDFPageObj_SetStrokeColor\0")?),
+                extern_FPDFPageObj_GetStrokeColor: *(library
+                    .get(b"FPDFPageObj_GetStrokeColor\0")?),
+                extern_FPDFPageObj_SetStrokeWidth: *(library
+                    .get(b"FPDFPageObj_SetStrokeWidth\0")?),
+                extern_FPDFPageObj_GetStrokeWidth: *(library
+                    .get(b"FPDFPageObj_GetStrokeWidth\0")?),
+                extern_FPDFPageObj_GetLineJoin: *(library.get(b"FPDFPageObj_GetLineJoin\0")?),
+                extern_FPDFPageObj_SetLineJoin: *(library.get(b"FPDFPageObj_SetLineJoin\0")?),
+                extern_FPDFPageObj_GetLineCap: *(library.get(b"FPDFPageObj_GetLineCap\0")?),
+                extern_FPDFPageObj_SetLineCap: *(library.get(b"FPDFPageObj_SetLineCap\0")?),
+                extern_FPDFPageObj_SetFillColor: *(library.get(b"FPDFPageObj_SetFillColor\0")?),
+                extern_FPDFPageObj_GetFillColor: *(library.get(b"FPDFPageObj_GetFillColor\0")?),
+                extern_FPDFPageObj_GetDashPhase: *(library.get(b"FPDFPageObj_GetDashPhase\0")?),
+                extern_FPDFPageObj_SetDashPhase: *(library.get(b"FPDFPageObj_SetDashPhase\0")?),
+                extern_FPDFPageObj_GetDashCount: *(library.get(b"FPDFPageObj_GetDashCount\0")?),
+                extern_FPDFPageObj_GetDashArray: *(library.get(b"FPDFPageObj_GetDashArray\0")?),
+                extern_FPDFPageObj_SetDashArray: *(library.get(b"FPDFPageObj_SetDashArray\0")?),
+                extern_FPDFPath_CountSegments: *(library.get(b"FPDFPath_CountSegments\0")?),
+                extern_FPDFPath_GetPathSegment: *(library.get(b"FPDFPath_GetPathSegment\0")?),
+                extern_FPDFPathSegment_GetPoint: *(library.get(b"FPDFPathSegment_GetPoint\0")?),
+                extern_FPDFPathSegment_GetType: *(library.get(b"FPDFPathSegment_GetType\0")?),
+                extern_FPDFPathSegment_GetClose: *(library.get(b"FPDFPathSegment_GetClose\0")?),
+                extern_FPDFFont_GetFontName: *(library.get(b"FPDFFont_GetFontName\0")?),
+                extern_FPDFFont_GetFlags: *(library.get(b"FPDFFont_GetFlags\0")?),
+                extern_FPDFFont_GetWeight: *(library.get(b"FPDFFont_GetWeight\0")?),
+                extern_FPDFFont_GetItalicAngle: *(library.get(b"FPDFFont_GetItalicAngle\0")?),
+                extern_FPDFFont_GetAscent: *(library.get(b"FPDFFont_GetAscent\0")?),
+                extern_FPDFFont_GetDescent: *(library.get(b"FPDFFont_GetDescent\0")?),
+                extern_FPDFFont_GetGlyphWidth: *(library.get(b"FPDFFont_GetGlyphWidth\0")?),
+                extern_FPDFFont_GetGlyphPath: *(library.get(b"FPDFFont_GetGlyphPath\0")?),
+                extern_FPDFGlyphPath_CountGlyphSegments: *(library
+                    .get(b"FPDFGlyphPath_CountGlyphSegments\0")?),
+                extern_FPDFGlyphPath_GetGlyphPathSegment: *(library
+                    .get(b"FPDFGlyphPath_GetGlyphPathSegment\0")?),
+                extern_FPDF_VIEWERREF_GetPrintScaling: *(library
+                    .get(b"FPDF_VIEWERREF_GetPrintScaling\0")?),
+                extern_FPDF_VIEWERREF_GetNumCopies: *(library
+                    .get(b"FPDF_VIEWERREF_GetNumCopies\0")?),
+                extern_FPDF_VIEWERREF_GetPrintPageRange: *(library
+                    .get(b"FPDF_VIEWERREF_GetPrintPageRange\0")?),
+                extern_FPDF_VIEWERREF_GetPrintPageRangeCount: *(library
+                    .get(b"FPDF_VIEWERREF_GetPrintPageRangeCount\0")?),
+                extern_FPDF_VIEWERREF_GetPrintPageRangeElement: *(library
+                    .get(b"FPDF_VIEWERREF_GetPrintPageRangeElement\0")?),
+                extern_FPDF_VIEWERREF_GetDuplex: *(library.get(b"FPDF_VIEWERREF_GetDuplex\0")?),
+                extern_FPDF_VIEWERREF_GetName: *(library.get(b"FPDF_VIEWERREF_GetName\0")?),
+                extern_FPDFDoc_GetAttachmentCount: *(library
+                    .get(b"FPDFDoc_GetAttachmentCount\0")?),
+                extern_FPDFDoc_AddAttachment: *(library.get(b"FPDFDoc_AddAttachment\0")?),
+                extern_FPDFDoc_GetAttachment: *(library.get(b"FPDFDoc_GetAttachment\0")?),
+                extern_FPDFDoc_DeleteAttachment: *(library.get(b"FPDFDoc_DeleteAttachment\0")?),
+                extern_FPDFAttachment_GetName: *(library.get(b"FPDFAttachment_GetName\0")?),
+                extern_FPDFAttachment_HasKey: *(library.get(b"FPDFAttachment_HasKey\0")?),
+                extern_FPDFAttachment_GetValueType: *(library
+                    .get(b"FPDFAttachment_GetValueType\0")?),
+                extern_FPDFAttachment_SetStringValue: *(library
+                    .get(b"FPDFAttachment_SetStringValue\0")?),
+                extern_FPDFAttachment_GetStringValue: *(library
+                    .get(b"FPDFAttachment_GetStringValue\0")?),
+                extern_FPDFAttachment_SetFile: *(library.get(b"FPDFAttachment_SetFile\0")?),
+                extern_FPDFAttachment_GetFile: *(library.get(b"FPDFAttachment_GetFile\0")?),
+                extern_FPDFCatalog_IsTagged: *(library.get(b"FPDFCatalog_IsTagged\0")?),
+                _library: library,
+            }
+        };
 
         Ok(result)
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_InitLibrary(&self) -> Result<Symbol<unsafe extern "C" fn()>, libloading::Error> {
-        unsafe { self.library.get(b"FPDF_InitLibrary\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_DestroyLibrary(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn()>, libloading::Error> {
-        unsafe { self.library.get(b"FPDF_DestroyLibrary\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_GetLastError(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn() -> c_ulong>, libloading::Error> {
-        unsafe { self.library.get(b"FPDF_GetLastError\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_CreateNewDocument(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn() -> FPDF_DOCUMENT>, libloading::Error> {
-        unsafe { self.library.get(b"FPDF_CreateNewDocument\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_LoadDocument(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                file_path: FPDF_STRING,
-                password: FPDF_BYTESTRING,
-            ) -> FPDF_DOCUMENT,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_LoadDocument\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_LoadMemDocument64(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                data_buf: *const c_void,
-                size: c_ulong,
-                password: FPDF_BYTESTRING,
-            ) -> FPDF_DOCUMENT,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_LoadMemDocument64\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_LoadCustomDocument(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                pFileAccess: *mut FPDF_FILEACCESS,
-                password: FPDF_BYTESTRING,
-            ) -> FPDF_DOCUMENT,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_LoadCustomDocument\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_SaveAsCopy(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                document: FPDF_DOCUMENT,
-                pFileWrite: *mut FPDF_FILEWRITE,
-                flags: FPDF_DWORD,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_SaveAsCopy\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_SaveWithVersion(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                document: FPDF_DOCUMENT,
-                pFileWrite: *mut FPDF_FILEWRITE,
-                flags: FPDF_DWORD,
-                fileVersion: c_int,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_SaveWithVersion\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_CloseDocument(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT)>, libloading::Error> {
-        unsafe { self.library.get(b"FPDF_CloseDocument\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_DeviceToPage(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page: FPDF_PAGE,
-                start_x: c_int,
-                start_y: c_int,
-                size_x: c_int,
-                size_y: c_int,
-                rotate: c_int,
-                device_x: c_int,
-                device_y: c_int,
-                page_x: *mut c_double,
-                page_y: *mut c_double,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_DeviceToPage\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_PageToDevice(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page: FPDF_PAGE,
-                start_x: c_int,
-                start_y: c_int,
-                size_x: c_int,
-                size_y: c_int,
-                rotate: c_int,
-                page_x: c_double,
-                page_y: c_double,
-                device_x: *mut c_int,
-                device_y: *mut c_int,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_PageToDevice\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_GetFileVersion(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(doc: FPDF_DOCUMENT, fileVersion: *mut c_int) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_GetFileVersion\0") }
-    }
-
-    #[allow(non_snake_case)]
-    fn extern_FPDF_GetFileIdentifier(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                document: FPDF_DOCUMENT,
-                id_type: FPDF_FILEIDTYPE,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_GetFileIdentifier\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_GetMetaText(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                document: FPDF_DOCUMENT,
-                tag: FPDF_BYTESTRING,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_GetMetaText\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_GetDocPermissions(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT) -> c_ulong>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDF_GetDocPermissions\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_GetSecurityHandlerRevision(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDF_GetSecurityHandlerRevision\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_GetPageCount(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDF_GetPageCount\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_LoadPage(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT, page_index: c_int) -> FPDF_PAGE>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_LoadPage\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_ClosePage(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(page: FPDF_PAGE)>, libloading::Error> {
-        unsafe { self.library.get(b"FPDF_ClosePage\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_ImportPagesByIndex(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                dest_doc: FPDF_DOCUMENT,
-                src_doc: FPDF_DOCUMENT,
-                page_indices: *const c_int,
-                length: c_ulong,
-                index: c_int,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_ImportPagesByIndex\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_ImportPages(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                dest_doc: FPDF_DOCUMENT,
-                src_doc: FPDF_DOCUMENT,
-                pagerange: FPDF_BYTESTRING,
-                index: c_int,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_ImportPages\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_ImportNPagesToOne(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                src_doc: FPDF_DOCUMENT,
-                output_width: c_float,
-                output_height: c_float,
-                num_pages_on_x_axis: size_t,
-                num_pages_on_y_axis: size_t,
-            ) -> FPDF_DOCUMENT,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_ImportNPagesToOne\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_GetPageLabel(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                document: FPDF_DOCUMENT,
-                page_index: c_int,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_GetPageLabel\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_GetPageBoundingBox(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page: FPDF_PAGE, rect: *mut FS_RECTF) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_GetPageBoundingBox\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_GetPageSizeByIndexF(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page: FPDF_DOCUMENT, page_index: c_int, size: *mut FS_SIZEF) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_GetPageSizeByIndexF\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_GetPageWidthF(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(page: FPDF_PAGE) -> c_float>, libloading::Error> {
-        unsafe { self.library.get(b"FPDF_GetPageWidthF\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_GetPageHeightF(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(page: FPDF_PAGE) -> c_float>, libloading::Error> {
-        unsafe { self.library.get(b"FPDF_GetPageHeightF\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetCharIndexFromTextIndex(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(text_page: FPDF_TEXTPAGE, nTextIndex: c_int) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_GetCharIndexFromTextIndex\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetTextIndexFromCharIndex(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(text_page: FPDF_TEXTPAGE, nCharIndex: c_int) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_GetTextIndexFromCharIndex\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_GetSignatureCount(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDF_GetSignatureCount\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_GetSignatureObject(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT, index: c_int) -> FPDF_SIGNATURE>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_GetSignatureObject\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFSignatureObj_GetContents(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                signature: FPDF_SIGNATURE,
-                buffer: *mut c_void,
-                length: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFSignatureObj_GetContents\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFSignatureObj_GetByteRange(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                signature: FPDF_SIGNATURE,
-                buffer: *mut c_int,
-                length: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFSignatureObj_GetByteRange\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFSignatureObj_GetSubFilter(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                signature: FPDF_SIGNATURE,
-                buffer: *mut c_char,
-                length: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFSignatureObj_GetSubFilter\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFSignatureObj_GetReason(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                signature: FPDF_SIGNATURE,
-                buffer: *mut c_void,
-                length: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFSignatureObj_GetReason\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFSignatureObj_GetTime(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                signature: FPDF_SIGNATURE,
-                buffer: *mut c_char,
-                length: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFSignatureObj_GetTime\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFSignatureObj_GetDocMDPPermission(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(signature: FPDF_SIGNATURE) -> c_uint>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFSignatureObj_GetDocMDPPermission\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_StructTree_GetForPage(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(page: FPDF_PAGE) -> FPDF_STRUCTTREE>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDF_StructTree_GetForPage\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_StructTree_Close(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(struct_tree: FPDF_STRUCTTREE)>, libloading::Error> {
-        unsafe { self.library.get(b"FPDF_StructTree_Close\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_StructTree_CountChildren(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(struct_tree: FPDF_STRUCTTREE) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_StructTree_CountChildren\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_StructTree_GetChildAtIndex(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(struct_tree: FPDF_STRUCTTREE, index: c_int) -> FPDF_STRUCTELEMENT,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_StructTree_GetChildAtIndex\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_StructElement_GetAltText(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                struct_element: FPDF_STRUCTELEMENT,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_StructElement_GetAltText\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_StructElement_GetID(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                struct_element: FPDF_STRUCTELEMENT,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_StructElement_GetID\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_StructElement_GetLang(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                struct_element: FPDF_STRUCTELEMENT,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_StructElement_GetLang\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_StructElement_GetStringAttribute(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                struct_element: FPDF_STRUCTELEMENT,
-                attr_name: FPDF_BYTESTRING,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_StructElement_GetStringAttribute\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_StructElement_GetMarkedContentID(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(struct_element: FPDF_STRUCTELEMENT) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_StructElement_GetMarkedContentID\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_StructElement_GetType(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                struct_element: FPDF_STRUCTELEMENT,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_StructElement_GetType\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_StructElement_GetTitle(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                struct_element: FPDF_STRUCTELEMENT,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_StructElement_GetTitle\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_StructElement_CountChildren(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(struct_element: FPDF_STRUCTELEMENT) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_StructElement_CountChildren\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_StructElement_GetChildAtIndex(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                struct_element: FPDF_STRUCTELEMENT,
-                index: c_int,
-            ) -> FPDF_STRUCTELEMENT,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_StructElement_GetChildAtIndex\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_New(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                document: FPDF_DOCUMENT,
-                page_index: c_int,
-                width: c_double,
-                height: c_double,
-            ) -> FPDF_PAGE,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_New\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_Delete(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT, page_index: c_int)>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_Delete\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_GetRotation(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(page: FPDF_PAGE) -> c_int>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFPage_GetRotation\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_SetRotation(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(page: FPDF_PAGE, rotate: c_int)>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFPage_SetRotation\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_GetMediaBox(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page: FPDF_PAGE,
-                left: *mut c_float,
-                bottom: *mut c_float,
-                right: *mut c_float,
-                top: *mut c_float,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_GetMediaBox\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_GetCropBox(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page: FPDF_PAGE,
-                left: *mut c_float,
-                bottom: *mut c_float,
-                right: *mut c_float,
-                top: *mut c_float,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_GetCropBox\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_GetBleedBox(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page: FPDF_PAGE,
-                left: *mut c_float,
-                bottom: *mut c_float,
-                right: *mut c_float,
-                top: *mut c_float,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_GetBleedBox\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_GetTrimBox(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page: FPDF_PAGE,
-                left: *mut c_float,
-                bottom: *mut c_float,
-                right: *mut c_float,
-                top: *mut c_float,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_GetTrimBox\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_GetArtBox(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page: FPDF_PAGE,
-                left: *mut c_float,
-                bottom: *mut c_float,
-                right: *mut c_float,
-                top: *mut c_float,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_GetArtBox\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_SetMediaBox(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page: FPDF_PAGE,
-                left: c_float,
-                bottom: c_float,
-                right: c_float,
-                top: c_float,
-            ),
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_SetMediaBox\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_SetCropBox(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page: FPDF_PAGE,
-                left: c_float,
-                bottom: c_float,
-                right: c_float,
-                top: c_float,
-            ),
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_SetCropBox\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_SetBleedBox(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page: FPDF_PAGE,
-                left: c_float,
-                bottom: c_float,
-                right: c_float,
-                top: c_float,
-            ),
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_SetBleedBox\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_SetTrimBox(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page: FPDF_PAGE,
-                left: c_float,
-                bottom: c_float,
-                right: c_float,
-                top: c_float,
-            ),
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_SetTrimBox\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_SetArtBox(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page: FPDF_PAGE,
-                left: c_float,
-                bottom: c_float,
-                right: c_float,
-                top: c_float,
-            ),
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_SetArtBox\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_TransFormWithClip(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page: FPDF_PAGE,
-                matrix: *const FS_MATRIX,
-                clipRect: *const FS_RECTF,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_TransFormWithClip\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_TransformClipPath(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page_object: FPDF_PAGEOBJECT,
-                a: f64,
-                b: f64,
-                c: f64,
-                d: f64,
-                e: f64,
-                f: f64,
-            ),
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_TransformClipPath\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_GetClipPath(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT) -> FPDF_CLIPPATH>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_GetClipPath\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFClipPath_CountPaths(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(clip_path: FPDF_CLIPPATH) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFClipPath_CountPaths\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFClipPath_CountPathSegments(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(clip_path: FPDF_CLIPPATH, path_index: c_int) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFClipPath_CountPathSegments\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFClipPath_GetPathSegment(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                clip_path: FPDF_CLIPPATH,
-                path_index: c_int,
-                segment_index: c_int,
-            ) -> FPDF_PATHSEGMENT,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFClipPath_GetPathSegment\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_CreateClipPath(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(left: f32, bottom: f32, right: f32, top: f32) -> FPDF_CLIPPATH>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_CreateClipPath\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_DestroyClipPath(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(clipPath: FPDF_CLIPPATH)>, libloading::Error> {
-        unsafe { self.library.get(b"FPDF_DestroyClipPath\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_InsertClipPath(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page: FPDF_PAGE, clipPath: FPDF_CLIPPATH)>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_InsertClipPath\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_HasTransparency(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(page: FPDF_PAGE) -> FPDF_BOOL>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFPage_HasTransparency\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_GenerateContent(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(page: FPDF_PAGE) -> FPDF_BOOL>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFPage_GenerateContent\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFBitmap_CreateEx(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                width: c_int,
-                height: c_int,
-                format: c_int,
-                first_scan: *mut c_void,
-                stride: c_int,
-            ) -> FPDF_BITMAP,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFBitmap_CreateEx\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFBitmap_Destroy(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(bitmap: FPDF_BITMAP)>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFBitmap_Destroy\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFBitmap_GetFormat(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(bitmap: FPDF_BITMAP) -> c_int>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFBitmap_GetFormat\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFBitmap_FillRect(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                bitmap: FPDF_BITMAP,
-                left: c_int,
-                top: c_int,
-                width: c_int,
-                height: c_int,
-                color: FPDF_DWORD,
-            ),
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFBitmap_FillRect\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFBitmap_GetBuffer(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(bitmap: FPDF_BITMAP) -> *mut c_void>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFBitmap_GetBuffer\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFBitmap_GetWidth(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(bitmap: FPDF_BITMAP) -> c_int>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFBitmap_GetWidth\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFBitmap_GetHeight(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(bitmap: FPDF_BITMAP) -> c_int>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFBitmap_GetHeight\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFBitmap_GetStride(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(bitmap: FPDF_BITMAP) -> c_int>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFBitmap_GetStride\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    #[allow(clippy::type_complexity)]
-    fn extern_FPDF_RenderPageBitmap(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                bitmap: FPDF_BITMAP,
-                page: FPDF_PAGE,
-                start_x: c_int,
-                start_y: c_int,
-                size_x: c_int,
-                size_y: c_int,
-                rotate: c_int,
-                flags: c_int,
-            ),
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_RenderPageBitmap\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    #[allow(clippy::type_complexity)]
-    fn extern_FPDF_RenderPageBitmapWithMatrix(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                bitmap: FPDF_BITMAP,
-                page: FPDF_PAGE,
-                matrix: *const FS_MATRIX,
-                clipping: *const FS_RECTF,
-                flags: c_int,
-            ),
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_RenderPageBitmapWithMatrix\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_IsSupportedSubtype(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(subtype: FPDF_ANNOTATION_SUBTYPE) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_IsSupportedSubtype\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_CreateAnnot(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page: FPDF_PAGE,
-                subtype: FPDF_ANNOTATION_SUBTYPE,
-            ) -> FPDF_ANNOTATION,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_CreateAnnot\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_GetAnnotCount(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(page: FPDF_PAGE) -> c_int>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFPage_GetAnnotCount\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_GetAnnot(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page: FPDF_PAGE, index: c_int) -> FPDF_ANNOTATION>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_GetAnnot\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_GetAnnotIndex(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page: FPDF_PAGE, annot: FPDF_ANNOTATION) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_GetAnnotIndex\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_CloseAnnot(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(annot: FPDF_ANNOTATION)>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFPage_CloseAnnot\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_RemoveAnnot(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page: FPDF_PAGE, index: c_int) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_RemoveAnnot\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetSubtype(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(annot: FPDF_ANNOTATION) -> FPDF_ANNOTATION_SUBTYPE>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetSubtype\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_IsObjectSupportedSubtype(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(subtype: FPDF_ANNOTATION_SUBTYPE) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_IsObjectSupportedSubtype\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_UpdateObject(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(annot: FPDF_ANNOTATION, obj: FPDF_PAGEOBJECT) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_UpdateObject\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_AddInkStroke(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                annot: FPDF_ANNOTATION,
-                points: *const FS_POINTF,
-                point_count: size_t,
-            ) -> c_int,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_AddInkStroke\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_RemoveInkList(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(annot: FPDF_ANNOTATION) -> FPDF_BOOL>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFAnnot_RemoveInkList\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_AppendObject(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(annot: FPDF_ANNOTATION, obj: FPDF_PAGEOBJECT) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_AppendObject\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetObjectCount(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(annot: FPDF_ANNOTATION) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFAnnot_GetObjectCount\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetObject(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(annot: FPDF_ANNOTATION, index: c_int) -> FPDF_PAGEOBJECT>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetObject\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_RemoveObject(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(annot: FPDF_ANNOTATION, index: c_int) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_RemoveObject\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    #[allow(clippy::type_complexity)]
-    fn extern_FPDFAnnot_SetColor(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                annot: FPDF_ANNOTATION,
-                color_type: FPDFANNOT_COLORTYPE,
-                R: c_uint,
-                G: c_uint,
-                B: c_uint,
-                A: c_uint,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_SetColor\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    #[allow(clippy::type_complexity)]
-    fn extern_FPDFAnnot_GetColor(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                annot: FPDF_ANNOTATION,
-                color_type: FPDFANNOT_COLORTYPE,
-                R: *mut c_uint,
-                G: *mut c_uint,
-                B: *mut c_uint,
-                A: *mut c_uint,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetColor\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_HasAttachmentPoints(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(annot: FPDF_ANNOTATION) -> FPDF_BOOL>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFAnnot_HasAttachmentPoints\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_SetAttachmentPoints(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                annot: FPDF_ANNOTATION,
-                quad_index: size_t,
-                quad_points: *const FS_QUADPOINTSF,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_SetAttachmentPoints\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_AppendAttachmentPoints(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                annot: FPDF_ANNOTATION,
-                quad_points: *const FS_QUADPOINTSF,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_AppendAttachmentPoints\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_CountAttachmentPoints(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(annot: FPDF_ANNOTATION) -> size_t>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFAnnot_CountAttachmentPoints\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetAttachmentPoints(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                annot: FPDF_ANNOTATION,
-                quad_index: size_t,
-                quad_points: *mut FS_QUADPOINTSF,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetAttachmentPoints\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_SetRect(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(annot: FPDF_ANNOTATION, rect: *const FS_RECTF) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_SetRect\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetRect(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(annot: FPDF_ANNOTATION, rect: *mut FS_RECTF) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetRect\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetVertices(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                annot: FPDF_ANNOTATION,
-                buffer: *mut FS_POINTF,
-                length: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetVertices\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetInkListCount(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(annot: FPDF_ANNOTATION) -> c_ulong>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFAnnot_GetInkListCount\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetInkListPath(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                annot: FPDF_ANNOTATION,
-                path_index: c_ulong,
-                buffer: *mut FS_POINTF,
-                length: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetInkListPath\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetLine(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                annot: FPDF_ANNOTATION,
-                start: *mut FS_POINTF,
-                end: *mut FS_POINTF,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetLine\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_SetBorder(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                annot: FPDF_ANNOTATION,
-                horizontal_radius: f32,
-                vertical_radius: f32,
-                border_width: f32,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_SetBorder\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetBorder(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                annot: FPDF_ANNOTATION,
-                horizontal_radius: *mut f32,
-                vertical_radius: *mut f32,
-                border_width: *mut f32,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetBorder\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_HasKey(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(annot: FPDF_ANNOTATION, key: FPDF_BYTESTRING) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_HasKey\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetValueType(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(annot: FPDF_ANNOTATION, key: FPDF_BYTESTRING) -> FPDF_OBJECT_TYPE,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetValueType\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_SetStringValue(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                annot: FPDF_ANNOTATION,
-                key: FPDF_BYTESTRING,
-                value: FPDF_WIDESTRING,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_SetStringValue\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetStringValue(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                annot: FPDF_ANNOTATION,
-                key: FPDF_BYTESTRING,
-                buffer: *mut FPDF_WCHAR,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetStringValue\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetNumberValue(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                annot: FPDF_ANNOTATION,
-                key: FPDF_BYTESTRING,
-                value: *mut f32,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetNumberValue\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_SetAP(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                annot: FPDF_ANNOTATION,
-                appearanceMode: FPDF_ANNOT_APPEARANCEMODE,
-                value: FPDF_WIDESTRING,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_SetAP\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetAP(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                annot: FPDF_ANNOTATION,
-                appearanceMode: FPDF_ANNOT_APPEARANCEMODE,
-                buffer: *mut FPDF_WCHAR,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetAP\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetLinkedAnnot(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(annot: FPDF_ANNOTATION, key: FPDF_BYTESTRING) -> FPDF_ANNOTATION,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetLinkedAnnot\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetFlags(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(annot: FPDF_ANNOTATION) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFAnnot_GetFlags\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_SetFlags(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(annot: FPDF_ANNOTATION, flags: c_int) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_SetFlags\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetFormFieldFlags(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(handle: FPDF_FORMHANDLE, annot: FPDF_ANNOTATION) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetFormFieldFlags\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetFormFieldAtPoint(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                hHandle: FPDF_FORMHANDLE,
-                page: FPDF_PAGE,
-                point: *const FS_POINTF,
-            ) -> FPDF_ANNOTATION,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetFormFieldAtPoint\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetFormFieldName(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                hHandle: FPDF_FORMHANDLE,
-                annot: FPDF_ANNOTATION,
-                buffer: *mut FPDF_WCHAR,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetFormFieldName\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetFormFieldType(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(hHandle: FPDF_FORMHANDLE, annot: FPDF_ANNOTATION) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetFormFieldType\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetFormFieldValue(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                hHandle: FPDF_FORMHANDLE,
-                annot: FPDF_ANNOTATION,
-                buffer: *mut FPDF_WCHAR,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetFormFieldValue\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetOptionCount(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(hHandle: FPDF_FORMHANDLE, annot: FPDF_ANNOTATION) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetOptionCount\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetOptionLabel(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                hHandle: FPDF_FORMHANDLE,
-                annot: FPDF_ANNOTATION,
-                index: c_int,
-                buffer: *mut FPDF_WCHAR,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetOptionLabel\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_IsOptionSelected(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                handle: FPDF_FORMHANDLE,
-                annot: FPDF_ANNOTATION,
-                index: c_int,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_IsOptionSelected\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetFontSize(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                hHandle: FPDF_FORMHANDLE,
-                annot: FPDF_ANNOTATION,
-                value: *mut f32,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetFontSize\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_IsChecked(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(hHandle: FPDF_FORMHANDLE, annot: FPDF_ANNOTATION) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_IsChecked\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_SetFocusableSubtypes(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                hHandle: FPDF_FORMHANDLE,
-                subtypes: *const FPDF_ANNOTATION_SUBTYPE,
-                count: size_t,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_SetFocusableSubtypes\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetFocusableSubtypesCount(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(hHandle: FPDF_FORMHANDLE) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFAnnot_GetFocusableSubtypesCount\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetFocusableSubtypes(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                hHandle: FPDF_FORMHANDLE,
-                subtypes: *mut FPDF_ANNOTATION_SUBTYPE,
-                count: size_t,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetFocusableSubtypes\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetLink(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(annot: FPDF_ANNOTATION) -> FPDF_LINK>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFAnnot_GetLink\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetFormControlCount(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(hHandle: FPDF_FORMHANDLE, annot: FPDF_ANNOTATION) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetFormControlCount\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetFormControlIndex(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(hHandle: FPDF_FORMHANDLE, annot: FPDF_ANNOTATION) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetFormControlIndex\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_GetFormFieldExportValue(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                hHandle: FPDF_FORMHANDLE,
-                annot: FPDF_ANNOTATION,
-                buffer: *mut FPDF_WCHAR,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_GetFormFieldExportValue\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAnnot_SetURI(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(annot: FPDF_ANNOTATION, uri: *const c_char) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAnnot_SetURI\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFDOC_InitFormFillEnvironment(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                document: FPDF_DOCUMENT,
-                form_info: *mut FPDF_FORMFILLINFO,
-            ) -> FPDF_FORMHANDLE,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFDOC_InitFormFillEnvironment\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFDOC_ExitFormFillEnvironment(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(handle: FPDF_FORMHANDLE)>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFDOC_ExitFormFillEnvironment\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FORM_OnAfterLoadPage(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page: FPDF_PAGE, handle: FPDF_FORMHANDLE)>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FORM_OnAfterLoadPage\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FORM_OnBeforeClosePage(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page: FPDF_PAGE, handle: FPDF_FORMHANDLE)>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FORM_OnBeforeClosePage\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFDoc_GetPageMode(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFDoc_GetPageMode\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_Flatten(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page: FPDF_PAGE, nFlag: c_int) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_Flatten\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_SetFormFieldHighlightColor(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(handle: FPDF_FORMHANDLE, field_type: c_int, color: c_ulong)>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_SetFormFieldHighlightColor\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_SetFormFieldHighlightAlpha(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(handle: FPDF_FORMHANDLE, alpha: c_uchar)>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_SetFormFieldHighlightAlpha\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    #[allow(clippy::type_complexity)]
-    fn extern_FPDF_FFLDraw(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                handle: FPDF_FORMHANDLE,
-                bitmap: FPDF_BITMAP,
-                page: FPDF_PAGE,
-                start_x: c_int,
-                start_y: c_int,
-                size_x: c_int,
-                size_y: c_int,
-                rotate: c_int,
-                flags: c_int,
-            ),
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_FFLDraw\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_GetFormType(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDF_GetFormType\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFBookmark_GetFirstChild(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(document: FPDF_DOCUMENT, bookmark: FPDF_BOOKMARK) -> FPDF_BOOKMARK,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFBookmark_GetFirstChild\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFBookmark_GetNextSibling(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(document: FPDF_DOCUMENT, bookmark: FPDF_BOOKMARK) -> FPDF_BOOKMARK,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFBookmark_GetNextSibling\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFBookmark_GetTitle(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                bookmark: FPDF_BOOKMARK,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFBookmark_GetTitle\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFBookmark_GetCount(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(bookmark: FPDF_BOOKMARK) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFBookmark_GetCount\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFBookmark_Find(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(document: FPDF_DOCUMENT, title: FPDF_WIDESTRING) -> FPDF_BOOKMARK,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFBookmark_Find\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFBookmark_GetDest(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT, bookmark: FPDF_BOOKMARK) -> FPDF_DEST>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFBookmark_GetDest\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFBookmark_GetAction(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(bookmark: FPDF_BOOKMARK) -> FPDF_ACTION>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFBookmark_GetAction\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAction_GetType(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(action: FPDF_ACTION) -> c_ulong>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFAction_GetType\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAction_GetDest(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT, action: FPDF_ACTION) -> FPDF_DEST>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAction_GetDest\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAction_GetFilePath(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                action: FPDF_ACTION,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAction_GetFilePath\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAction_GetURIPath(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                document: FPDF_DOCUMENT,
-                action: FPDF_ACTION,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAction_GetURIPath\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFDest_GetDestPageIndex(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT, dest: FPDF_DEST) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFDest_GetDestPageIndex\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFDest_GetView(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                dest: FPDF_DEST,
-                pNumParams: *mut c_ulong,
-                pParams: *mut FS_FLOAT,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFDest_GetView\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    #[allow(clippy::too_many_arguments)]
-    fn extern_FPDFDest_GetLocationInPage(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                dest: FPDF_DEST,
-                hasXVal: *mut FPDF_BOOL,
-                hasYVal: *mut FPDF_BOOL,
-                hasZoomVal: *mut FPDF_BOOL,
-                x: *mut FS_FLOAT,
-                y: *mut FS_FLOAT,
-                zoom: *mut FS_FLOAT,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFDest_GetLocationInPage\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFLink_GetLinkAtPoint(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page: FPDF_PAGE, x: c_double, y: c_double) -> FPDF_LINK>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFLink_GetLinkAtPoint\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFLink_GetLinkZOrderAtPoint(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page: FPDF_PAGE, x: c_double, y: c_double) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFLink_GetLinkZOrderAtPoint\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFLink_GetDest(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT, link: FPDF_LINK) -> FPDF_DEST>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFLink_GetDest\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFLink_GetAction(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(link: FPDF_LINK) -> FPDF_ACTION>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFLink_GetAction\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFLink_Enumerate(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page: FPDF_PAGE,
-                start_pos: *mut c_int,
-                link_annot: *mut FPDF_LINK,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFLink_Enumerate\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFLink_GetAnnot(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page: FPDF_PAGE, link_annot: FPDF_LINK) -> FPDF_ANNOTATION>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFLink_GetAnnot\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFLink_GetAnnotRect(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(link_annot: FPDF_LINK, rect: *mut FS_RECTF) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFLink_GetAnnotRect\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFLink_CountQuadPoints(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(link_annot: FPDF_LINK) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFLink_CountQuadPoints\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFLink_GetQuadPoints(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                link_annot: FPDF_LINK,
-                quad_index: c_int,
-                quad_points: *mut FS_QUADPOINTSF,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFLink_GetQuadPoints\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_GetPageAAction(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page: FPDF_PAGE, aa_type: c_int) -> FPDF_ACTION>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_GetPageAAction\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_LoadPage(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(page: FPDF_PAGE) -> FPDF_TEXTPAGE>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFText_LoadPage\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_ClosePage(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(text_page: FPDF_TEXTPAGE)>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFText_ClosePage\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_CountChars(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(text_page: FPDF_TEXTPAGE) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFText_CountChars\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetUnicode(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(text_page: FPDF_TEXTPAGE, index: c_int) -> c_uint>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_GetUnicode\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetFontSize(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(text_page: FPDF_TEXTPAGE, index: c_int) -> c_double>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_GetFontSize\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetFontInfo(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                text_page: FPDF_TEXTPAGE,
-                index: c_int,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-                flags: *mut c_int,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_GetFontInfo\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetFontWeight(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(text_page: FPDF_TEXTPAGE, index: c_int) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_GetFontWeight\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetTextRenderMode(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(text_page: FPDF_TEXTPAGE, index: c_int) -> FPDF_TEXT_RENDERMODE,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_GetTextRenderMode\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetFillColor(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                text_page: FPDF_TEXTPAGE,
-                index: c_int,
-                R: *mut c_uint,
-                G: *mut c_uint,
-                B: *mut c_uint,
-                A: *mut c_uint,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_GetFillColor\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetStrokeColor(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                text_page: FPDF_TEXTPAGE,
-                index: c_int,
-                R: *mut c_uint,
-                G: *mut c_uint,
-                B: *mut c_uint,
-                A: *mut c_uint,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_GetStrokeColor\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetCharAngle(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(text_page: FPDF_TEXTPAGE, index: c_int) -> c_float>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_GetCharAngle\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetCharBox(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                text_page: FPDF_TEXTPAGE,
-                index: c_int,
-                left: *mut c_double,
-                right: *mut c_double,
-                bottom: *mut c_double,
-                top: *mut c_double,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_GetCharBox\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetLooseCharBox(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                text_page: FPDF_TEXTPAGE,
-                index: c_int,
-                rect: *mut FS_RECTF,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_GetLooseCharBox\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetMatrix(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                text_page: FPDF_TEXTPAGE,
-                index: c_int,
-                matrix: *mut FS_MATRIX,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_GetMatrix\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetCharOrigin(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                text_page: FPDF_TEXTPAGE,
-                index: c_int,
-                x: *mut c_double,
-                y: *mut c_double,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_GetCharOrigin\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetCharIndexAtPos(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                text_page: FPDF_TEXTPAGE,
-                x: c_double,
-                y: c_double,
-                xTolerance: c_double,
-                yTolerance: c_double,
-            ) -> c_int,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_GetCharIndexAtPos\0") }
-    }
-
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetText(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                text_page: FPDF_TEXTPAGE,
-                start_index: c_int,
-                count: c_int,
-                result: *mut c_ushort,
-            ) -> c_int,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_GetText\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_CountRects(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                text_page: FPDF_TEXTPAGE,
-                start_index: c_int,
-                count: c_int,
-            ) -> c_int,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_CountRects\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetRect(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                text_page: FPDF_TEXTPAGE,
-                rect_index: c_int,
-                left: *mut c_double,
-                top: *mut c_double,
-                right: *mut c_double,
-                bottom: *mut c_double,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_GetRect\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    #[allow(clippy::type_complexity)]
-    fn extern_FPDFText_GetBoundedText(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                text_page: FPDF_TEXTPAGE,
-                left: c_double,
-                top: c_double,
-                right: c_double,
-                bottom: c_double,
-                buffer: *mut c_ushort,
-                buflen: c_int,
-            ) -> c_int,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_GetBoundedText\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_FindStart(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                text_page: FPDF_TEXTPAGE,
-                findwhat: FPDF_WIDESTRING,
-                flags: c_ulong,
-                start_index: c_int,
-            ) -> FPDF_SCHHANDLE,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_FindStart\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_FindNext(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(handle: FPDF_SCHHANDLE) -> FPDF_BOOL>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFText_FindNext\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_FindPrev(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(handle: FPDF_SCHHANDLE) -> FPDF_BOOL>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFText_FindPrev\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetSchResultIndex(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(handle: FPDF_SCHHANDLE) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFText_GetSchResultIndex\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_GetSchCount(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(handle: FPDF_SCHHANDLE) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFText_GetSchCount\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_FindClose(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(handle: FPDF_SCHHANDLE)>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFText_FindClose\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFLink_LoadWebLinks(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(text_page: FPDF_TEXTPAGE) -> FPDF_PAGELINK>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFLink_LoadWebLinks\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFLink_CountWebLinks(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(link_page: FPDF_PAGELINK) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFLink_CountWebLinks\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFLink_GetURL(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                link_page: FPDF_PAGELINK,
-                link_index: c_int,
-                buffer: *mut c_ushort,
-                buflen: c_int,
-            ) -> c_int,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFLink_GetURL\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFLink_CountRects(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(link_page: FPDF_PAGELINK, link_index: c_int) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFLink_CountRects\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    #[allow(clippy::too_many_arguments)]
-    fn extern_FPDFLink_GetRect(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                link_page: FPDF_PAGELINK,
-                link_index: c_int,
-                rect_index: c_int,
-                left: *mut c_double,
-                top: *mut c_double,
-                right: *mut c_double,
-                bottom: *mut c_double,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFLink_GetRect\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFLink_GetTextRange(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                link_page: FPDF_PAGELINK,
-                link_index: c_int,
-                start_char_index: *mut c_int,
-                char_count: *mut c_int,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFLink_GetTextRange\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFLink_CloseWebLinks(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(link_page: FPDF_PAGELINK)>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFLink_CloseWebLinks\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_GetDecodedThumbnailData(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(page: FPDF_PAGE, buffer: *mut c_void, buflen: c_ulong) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_GetDecodedThumbnailData\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_GetRawThumbnailData(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(page: FPDF_PAGE, buffer: *mut c_void, buflen: c_ulong) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_GetRawThumbnailData\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_GetThumbnailAsBitmap(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(page: FPDF_PAGE) -> FPDF_BITMAP>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFPage_GetThumbnailAsBitmap\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFFormObj_CountObjects(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(form_object: FPDF_PAGEOBJECT) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFFormObj_CountObjects\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFFormObj_GetObject(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(form_object: FPDF_PAGEOBJECT, index: c_ulong) -> FPDF_PAGEOBJECT,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFFormObj_GetObject\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_CreateTextObj(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                document: FPDF_DOCUMENT,
-                font: FPDF_FONT,
-                font_size: c_float,
-            ) -> FPDF_PAGEOBJECT,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_CreateTextObj\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFTextObj_GetTextRenderMode(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(text: FPDF_PAGEOBJECT) -> FPDF_TEXT_RENDERMODE>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFTextObj_GetTextRenderMode\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFTextObj_SetTextRenderMode(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                text: FPDF_PAGEOBJECT,
-                render_mode: FPDF_TEXT_RENDERMODE,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFTextObj_SetTextRenderMode\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFTextObj_GetText(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                text_object: FPDF_PAGEOBJECT,
-                text_page: FPDF_TEXTPAGE,
-                buffer: *mut FPDF_WCHAR,
-                length: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFTextObj_GetText\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFTextObj_GetFont(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(text: FPDF_PAGEOBJECT) -> FPDF_FONT>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFTextObj_GetFont\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFTextObj_GetFontSize(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(text: FPDF_PAGEOBJECT, size: *mut c_float) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFTextObj_GetFontSize\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_NewTextObj(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                document: FPDF_DOCUMENT,
-                font: FPDF_BYTESTRING,
-                font_size: c_float,
-            ) -> FPDF_PAGEOBJECT,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_NewTextObj\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_SetText(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(text_object: FPDF_PAGEOBJECT, text: FPDF_WIDESTRING) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_SetText\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_SetCharcodes(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                text_object: FPDF_PAGEOBJECT,
-                charcodes: *const c_uint,
-                count: size_t,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_SetCharcodes\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_LoadFont(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                document: FPDF_DOCUMENT,
-                data: *const c_uchar,
-                size: c_uint,
-                font_type: c_int,
-                cid: FPDF_BOOL,
-            ) -> FPDF_FONT,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_LoadFont\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFText_LoadStandardFont(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT, font: FPDF_BYTESTRING) -> FPDF_FONT>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFText_LoadStandardFont\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFFont_Close(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(font: FPDF_FONT)>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFFont_Close\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPath_MoveTo(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(path: FPDF_PAGEOBJECT, x: c_float, y: c_float) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPath_MoveTo\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPath_LineTo(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(path: FPDF_PAGEOBJECT, x: c_float, y: c_float) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPath_LineTo\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPath_BezierTo(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                path: FPDF_PAGEOBJECT,
-                x1: c_float,
-                y1: c_float,
-                x2: c_float,
-                y2: c_float,
-                x3: c_float,
-                y3: c_float,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPath_BezierTo\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPath_Close(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(path: FPDF_PAGEOBJECT) -> FPDF_BOOL>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFPath_Close\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPath_SetDrawMode(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                path: FPDF_PAGEOBJECT,
-                fillmode: c_int,
-                stroke: FPDF_BOOL,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPath_SetDrawMode\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPath_GetDrawMode(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                path: FPDF_PAGEOBJECT,
-                fillmode: *mut c_int,
-                stroke: *mut FPDF_BOOL,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPath_GetDrawMode\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_InsertObject(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page: FPDF_PAGE, page_obj: FPDF_PAGEOBJECT)>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_InsertObject\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_RemoveObject(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page: FPDF_PAGE, page_obj: FPDF_PAGEOBJECT) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_RemoveObject\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_CountObjects(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(page: FPDF_PAGE) -> c_int>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFPage_CountObjects\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPage_GetObject(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page: FPDF_PAGE, index: c_int) -> FPDF_PAGEOBJECT>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPage_GetObject\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_Destroy(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(page_obj: FPDF_PAGEOBJECT)>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFPageObj_Destroy\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_HasTransparency(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_HasTransparency\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_GetType(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_GetType\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    #[allow(clippy::type_complexity)]
-    fn extern_FPDFPageObj_Transform(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page_object: FPDF_PAGEOBJECT,
-                a: c_double,
-                b: c_double,
-                c: c_double,
-                d: c_double,
-                e: c_double,
-                f: c_double,
-            ),
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_Transform\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_GetMatrix(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT, matrix: *mut FS_MATRIX) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_GetMatrix\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_SetMatrix(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(path: FPDF_PAGEOBJECT, matrix: *const FS_MATRIX) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_SetMatrix\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_NewImageObj(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT) -> FPDF_PAGEOBJECT>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_NewImageObj\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_CountMarks(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_CountMarks\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_GetMark(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page_object: FPDF_PAGEOBJECT,
-                index: c_ulong,
-            ) -> FPDF_PAGEOBJECTMARK,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_GetMark\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_AddMark(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page_object: FPDF_PAGEOBJECT,
-                name: FPDF_BYTESTRING,
-            ) -> FPDF_PAGEOBJECTMARK,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_AddMark\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_RemoveMark(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page_object: FPDF_PAGEOBJECT,
-                mark: FPDF_PAGEOBJECTMARK,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_RemoveMark\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObjMark_GetName(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                mark: FPDF_PAGEOBJECTMARK,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-                out_buflen: *mut c_ulong,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObjMark_GetName\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObjMark_CountParams(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(mark: FPDF_PAGEOBJECTMARK) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFPageObjMark_CountParams\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObjMark_GetParamKey(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                mark: FPDF_PAGEOBJECTMARK,
-                index: c_ulong,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-                out_buflen: *mut c_ulong,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObjMark_GetParamKey\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObjMark_GetParamValueType(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                mark: FPDF_PAGEOBJECTMARK,
-                key: FPDF_BYTESTRING,
-            ) -> FPDF_OBJECT_TYPE,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObjMark_GetParamValueType\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObjMark_GetParamIntValue(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                mark: FPDF_PAGEOBJECTMARK,
-                key: FPDF_BYTESTRING,
-                out_value: *mut c_int,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObjMark_GetParamIntValue\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObjMark_GetParamStringValue(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                mark: FPDF_PAGEOBJECTMARK,
-                key: FPDF_BYTESTRING,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-                out_buflen: *mut c_ulong,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObjMark_GetParamStringValue\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObjMark_GetParamBlobValue(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                mark: FPDF_PAGEOBJECTMARK,
-                key: FPDF_BYTESTRING,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-                out_buflen: *mut c_ulong,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObjMark_GetParamBlobValue\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObjMark_SetIntParam(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                document: FPDF_DOCUMENT,
-                page_object: FPDF_PAGEOBJECT,
-                mark: FPDF_PAGEOBJECTMARK,
-                key: FPDF_BYTESTRING,
-                value: c_int,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObjMark_SetIntParam\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObjMark_SetStringParam(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                document: FPDF_DOCUMENT,
-                page_object: FPDF_PAGEOBJECT,
-                mark: FPDF_PAGEOBJECTMARK,
-                key: FPDF_BYTESTRING,
-                value: FPDF_BYTESTRING,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObjMark_SetStringParam\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    #[allow(clippy::type_complexity)]
-    fn extern_FPDFPageObjMark_SetBlobParam(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                document: FPDF_DOCUMENT,
-                page_object: FPDF_PAGEOBJECT,
-                mark: FPDF_PAGEOBJECTMARK,
-                key: FPDF_BYTESTRING,
-                value: *mut c_void,
-                value_len: c_ulong,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObjMark_SetBlobParam\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObjMark_RemoveParam(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page_object: FPDF_PAGEOBJECT,
-                mark: FPDF_PAGEOBJECTMARK,
-                key: FPDF_BYTESTRING,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObjMark_RemoveParam\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFImageObj_LoadJpegFile(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                pages: *mut FPDF_PAGE,
-                count: c_int,
-                image_object: FPDF_PAGEOBJECT,
-                file_access: *mut FPDF_FILEACCESS,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFImageObj_LoadJpegFile\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFImageObj_LoadJpegFileInline(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                pages: *mut FPDF_PAGE,
-                count: c_int,
-                image_object: FPDF_PAGEOBJECT,
-                file_access: *mut FPDF_FILEACCESS,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFImageObj_LoadJpegFileInline\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    #[allow(clippy::type_complexity)]
-    fn extern_FPDFImageObj_SetMatrix(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                image_object: FPDF_PAGEOBJECT,
-                a: c_double,
-                b: c_double,
-                c: c_double,
-                d: c_double,
-                e: c_double,
-                f: c_double,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFImageObj_SetMatrix\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFImageObj_SetBitmap(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                pages: *mut FPDF_PAGE,
-                count: c_int,
-                image_object: FPDF_PAGEOBJECT,
-                bitmap: FPDF_BITMAP,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFImageObj_SetBitmap\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFImageObj_GetBitmap(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(image_object: FPDF_PAGEOBJECT) -> FPDF_BITMAP>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFImageObj_GetBitmap\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFImageObj_GetRenderedBitmap(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                document: FPDF_DOCUMENT,
-                page: FPDF_PAGE,
-                image_object: FPDF_PAGEOBJECT,
-            ) -> FPDF_BITMAP,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFImageObj_GetRenderedBitmap\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFImageObj_GetImageDataDecoded(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                image_object: FPDF_PAGEOBJECT,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFImageObj_GetImageDataDecoded\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFImageObj_GetImageDataRaw(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                image_object: FPDF_PAGEOBJECT,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFImageObj_GetImageDataRaw\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFImageObj_GetImageFilterCount(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(image_object: FPDF_PAGEOBJECT) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFImageObj_GetImageFilterCount\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFImageObj_GetImageFilter(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                image_object: FPDF_PAGEOBJECT,
-                index: c_int,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFImageObj_GetImageFilter\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFImageObj_GetImageMetadata(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                image_object: FPDF_PAGEOBJECT,
-                page: FPDF_PAGE,
-                metadata: *mut FPDF_IMAGEOBJ_METADATA,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFImageObj_GetImageMetadata\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_CreateNewPath(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(x: c_float, y: c_float) -> FPDF_PAGEOBJECT>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_CreateNewPath\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_CreateNewRect(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(x: c_float, y: c_float, w: c_float, h: c_float) -> FPDF_PAGEOBJECT,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_CreateNewRect\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_GetBounds(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page_object: FPDF_PAGEOBJECT,
-                left: *mut c_float,
-                bottom: *mut c_float,
-                right: *mut c_float,
-                top: *mut c_float,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_GetBounds\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_SetBlendMode(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT, blend_mode: FPDF_BYTESTRING)>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_SetBlendMode\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_SetStrokeColor(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page_object: FPDF_PAGEOBJECT,
-                R: c_uint,
-                G: c_uint,
-                B: c_uint,
-                A: c_uint,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_SetStrokeColor\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_GetStrokeColor(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page_object: FPDF_PAGEOBJECT,
-                R: *mut c_uint,
-                G: *mut c_uint,
-                B: *mut c_uint,
-                A: *mut c_uint,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_GetStrokeColor\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_SetStrokeWidth(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT, width: c_float) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_SetStrokeWidth\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_GetStrokeWidth(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT, width: *mut c_float) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_GetStrokeWidth\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_GetLineJoin(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_GetLineJoin\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_SetLineJoin(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT, line_join: c_int) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_SetLineJoin\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_GetLineCap(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_GetLineCap\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_SetLineCap(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT, line_cap: c_int) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_SetLineCap\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_SetFillColor(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page_object: FPDF_PAGEOBJECT,
-                R: c_uint,
-                G: c_uint,
-                B: c_uint,
-                A: c_uint,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_SetFillColor\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_GetFillColor(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page_object: FPDF_PAGEOBJECT,
-                R: *mut c_uint,
-                G: *mut c_uint,
-                B: *mut c_uint,
-                A: *mut c_uint,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_GetFillColor\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_GetDashPhase(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT, phase: *mut c_float) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_GetDashPhase\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_SetDashPhase(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT, phase: c_float) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_SetDashPhase\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_GetDashCount(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(page_object: FPDF_PAGEOBJECT) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_GetDashCount\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_GetDashArray(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page_object: FPDF_PAGEOBJECT,
-                dash_array: *mut c_float,
-                dash_count: size_t,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_GetDashArray\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPageObj_SetDashArray(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                page_object: FPDF_PAGEOBJECT,
-                dash_array: *const c_float,
-                dash_count: size_t,
-                phase: c_float,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPageObj_SetDashArray\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPath_CountSegments(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(path: FPDF_PAGEOBJECT) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFPath_CountSegments\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPath_GetPathSegment(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(path: FPDF_PAGEOBJECT, index: c_int) -> FPDF_PATHSEGMENT>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPath_GetPathSegment\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPathSegment_GetPoint(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(segment: FPDF_PATHSEGMENT, x: *mut f32, y: *mut f32) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPathSegment_GetPoint\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPathSegment_GetType(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(segment: FPDF_PATHSEGMENT) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFPathSegment_GetType\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFPathSegment_GetClose(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(segment: FPDF_PATHSEGMENT) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFPathSegment_GetClose\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFFont_GetFontName(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(font: FPDF_FONT, buffer: *mut c_char, length: c_ulong) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFFont_GetFontName\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFFont_GetFlags(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(font: FPDF_FONT) -> c_int>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFFont_GetFlags\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFFont_GetWeight(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(font: FPDF_FONT) -> c_int>, libloading::Error> {
-        unsafe { self.library.get(b"FPDFFont_GetWeight\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFFont_GetItalicAngle(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(font: FPDF_FONT, angle: *mut c_int) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFFont_GetItalicAngle\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFFont_GetAscent(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                font: FPDF_FONT,
-                font_size: c_float,
-                ascent: *mut c_float,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFFont_GetAscent\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFFont_GetDescent(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                font: FPDF_FONT,
-                font_size: c_float,
-                descent: *mut c_float,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFFont_GetDescent\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFFont_GetGlyphWidth(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                font: FPDF_FONT,
-                glyph: c_uint,
-                font_size: c_float,
-                width: *mut c_float,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFFont_GetGlyphWidth\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFFont_GetGlyphPath(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                font: FPDF_FONT,
-                glyph: c_uint,
-                font_size: c_float,
-            ) -> FPDF_GLYPHPATH,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFFont_GetGlyphPath\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFGlyphPath_CountGlyphSegments(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(glyphpath: FPDF_GLYPHPATH) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFGlyphPath_CountGlyphSegments\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFGlyphPath_GetGlyphPathSegment(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(glyphpath: FPDF_GLYPHPATH, index: c_int) -> FPDF_PATHSEGMENT>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFGlyphPath_GetGlyphPathSegment\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_VIEWERREF_GetPrintScaling(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT) -> FPDF_BOOL>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDF_VIEWERREF_GetPrintScaling\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_VIEWERREF_GetNumCopies(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDF_VIEWERREF_GetNumCopies\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_VIEWERREF_GetPrintPageRange(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT) -> FPDF_PAGERANGE>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_VIEWERREF_GetPrintPageRange\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_VIEWERREF_GetPrintPageRangeCount(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(pagerange: FPDF_PAGERANGE) -> size_t>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDF_VIEWERREF_GetPrintPageRangeCount\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_VIEWERREF_GetPrintPageRangeElement(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(pagerange: FPDF_PAGERANGE, index: size_t) -> c_int>,
-        libloading::Error,
-    > {
-        unsafe {
-            self.library
-                .get(b"FPDF_VIEWERREF_GetPrintPageRangeElement\0")
-        }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_VIEWERREF_GetDuplex(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT) -> FPDF_DUPLEXTYPE>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_VIEWERREF_GetDuplex\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDF_VIEWERREF_GetName(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                document: FPDF_DOCUMENT,
-                key: FPDF_BYTESTRING,
-                buffer: *mut c_char,
-                length: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDF_VIEWERREF_GetName\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFDoc_GetAttachmentCount(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT) -> c_int>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFDoc_GetAttachmentCount\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFDoc_AddAttachment(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(document: FPDF_DOCUMENT, name: FPDF_WIDESTRING) -> FPDF_ATTACHMENT,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFDoc_AddAttachment\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFDoc_GetAttachment(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT, index: c_int) -> FPDF_ATTACHMENT>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFDoc_GetAttachment\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFDoc_DeleteAttachment(
-        &self,
-    ) -> Result<
-        Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT, index: c_int) -> FPDF_BOOL>,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFDoc_DeleteAttachment\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAttachment_GetName(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                attachment: FPDF_ATTACHMENT,
-                buffer: *mut FPDF_WCHAR,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAttachment_GetName\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAttachment_HasKey(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(attachment: FPDF_ATTACHMENT, key: FPDF_BYTESTRING) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAttachment_HasKey\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAttachment_GetValueType(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                attachment: FPDF_ATTACHMENT,
-                key: FPDF_BYTESTRING,
-            ) -> FPDF_OBJECT_TYPE,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAttachment_GetValueType\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAttachment_SetStringValue(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                attachment: FPDF_ATTACHMENT,
-                key: FPDF_BYTESTRING,
-                value: FPDF_WIDESTRING,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAttachment_SetStringValue\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAttachment_GetStringValue(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                attachment: FPDF_ATTACHMENT,
-                key: FPDF_BYTESTRING,
-                buffer: *mut FPDF_WCHAR,
-                buflen: c_ulong,
-            ) -> c_ulong,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAttachment_GetStringValue\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAttachment_SetFile(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                attachment: FPDF_ATTACHMENT,
-                document: FPDF_DOCUMENT,
-                contents: *const c_void,
-                len: c_ulong,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAttachment_SetFile\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFAttachment_GetFile(
-        &self,
-    ) -> Result<
-        Symbol<
-            unsafe extern "C" fn(
-                attachment: FPDF_ATTACHMENT,
-                buffer: *mut c_void,
-                buflen: c_ulong,
-                out_buflen: *mut c_ulong,
-            ) -> FPDF_BOOL,
-        >,
-        libloading::Error,
-    > {
-        unsafe { self.library.get(b"FPDFAttachment_GetFile\0") }
-    }
-
-    #[inline]
-    #[allow(non_snake_case)]
-    fn extern_FPDFCatalog_IsTagged(
-        &self,
-    ) -> Result<Symbol<unsafe extern "C" fn(document: FPDF_DOCUMENT) -> FPDF_BOOL>, libloading::Error>
-    {
-        unsafe { self.library.get(b"FPDFCatalog_IsTagged\0") }
     }
 }
 
@@ -4828,7 +1587,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     #[allow(non_snake_case)]
     fn FPDF_InitLibrary(&self) {
         unsafe {
-            self.extern_FPDF_InitLibrary().unwrap()();
+            (self.extern_FPDF_InitLibrary)();
         }
     }
 
@@ -4836,20 +1595,20 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     #[allow(non_snake_case)]
     fn FPDF_DestroyLibrary(&self) {
         unsafe {
-            self.extern_FPDF_DestroyLibrary().unwrap()();
+            (self.extern_FPDF_DestroyLibrary)();
         }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_GetLastError(&self) -> c_ulong {
-        unsafe { self.extern_FPDF_GetLastError().unwrap()() }
+        unsafe { (self.extern_FPDF_GetLastError)() }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_CreateNewDocument(&self) -> FPDF_DOCUMENT {
-        unsafe { self.extern_FPDF_CreateNewDocument().unwrap()() }
+        unsafe { (self.extern_FPDF_CreateNewDocument)() }
     }
 
     #[inline]
@@ -4858,9 +1617,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         let c_file_path = CString::new(file_path).unwrap();
         let c_password = CString::new(password.unwrap_or("")).unwrap();
 
-        unsafe {
-            self.extern_FPDF_LoadDocument().unwrap()(c_file_path.as_ptr(), c_password.as_ptr())
-        }
+        unsafe { (self.extern_FPDF_LoadDocument)(c_file_path.as_ptr(), c_password.as_ptr()) }
     }
 
     #[inline]
@@ -4869,7 +1626,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         let c_password = CString::new(password.unwrap_or("")).unwrap();
 
         unsafe {
-            self.extern_FPDF_LoadMemDocument64().unwrap()(
+            (self.extern_FPDF_LoadMemDocument64)(
                 bytes.as_ptr() as *const c_void,
                 bytes.len() as c_ulong,
                 c_password.as_ptr(),
@@ -4886,7 +1643,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     ) -> FPDF_DOCUMENT {
         let c_password = CString::new(password.unwrap_or("")).unwrap();
 
-        unsafe { self.extern_FPDF_LoadCustomDocument().unwrap()(pFileAccess, c_password.as_ptr()) }
+        unsafe { (self.extern_FPDF_LoadCustomDocument)(pFileAccess, c_password.as_ptr()) }
     }
 
     #[inline]
@@ -4897,7 +1654,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         pFileWrite: *mut FPDF_FILEWRITE,
         flags: FPDF_DWORD,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDF_SaveAsCopy().unwrap()(document, pFileWrite, flags) }
+        unsafe { (self.extern_FPDF_SaveAsCopy)(document, pFileWrite, flags) }
     }
 
     #[inline]
@@ -4909,16 +1666,14 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         flags: FPDF_DWORD,
         fileVersion: c_int,
     ) -> FPDF_BOOL {
-        unsafe {
-            self.extern_FPDF_SaveWithVersion().unwrap()(document, pFileWrite, flags, fileVersion)
-        }
+        unsafe { (self.extern_FPDF_SaveWithVersion)(document, pFileWrite, flags, fileVersion) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_CloseDocument(&self, document: FPDF_DOCUMENT) {
         unsafe {
-            self.extern_FPDF_CloseDocument().unwrap()(document);
+            (self.extern_FPDF_CloseDocument)(document);
         }
     }
 
@@ -4938,7 +1693,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         page_y: *mut c_double,
     ) -> FPDF_BOOL {
         unsafe {
-            self.extern_FPDF_DeviceToPage().unwrap()(
+            (self.extern_FPDF_DeviceToPage)(
                 page, start_x, start_y, size_x, size_y, rotate, device_x, device_y, page_x, page_y,
             )
         }
@@ -4960,7 +1715,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         device_y: *mut c_int,
     ) -> FPDF_BOOL {
         unsafe {
-            self.extern_FPDF_PageToDevice().unwrap()(
+            (self.extern_FPDF_PageToDevice)(
                 page, start_x, start_y, size_x, size_y, rotate, page_x, page_y, device_x, device_y,
             )
         }
@@ -4969,7 +1724,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_GetFileVersion(&self, doc: FPDF_DOCUMENT, fileVersion: *mut c_int) -> FPDF_BOOL {
-        unsafe { self.extern_FPDF_GetFileVersion().unwrap()(doc, fileVersion) }
+        unsafe { (self.extern_FPDF_GetFileVersion)(doc, fileVersion) }
     }
 
     #[inline]
@@ -4981,13 +1736,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_void,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDF_GetFileIdentifier().unwrap()(document, id_type, buffer, buflen) }
+        unsafe { (self.extern_FPDF_GetFileIdentifier)(document, id_type, buffer, buflen) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_GetFormType(&self, document: FPDF_DOCUMENT) -> c_int {
-        unsafe { self.extern_FPDF_GetFormType().unwrap()(document) }
+        unsafe { (self.extern_FPDF_GetFormType)(document) }
     }
 
     #[inline]
@@ -5001,38 +1756,38 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     ) -> c_ulong {
         let c_tag = CString::new(tag).unwrap();
 
-        unsafe { self.extern_FPDF_GetMetaText().unwrap()(document, c_tag.as_ptr(), buffer, buflen) }
+        unsafe { (self.extern_FPDF_GetMetaText)(document, c_tag.as_ptr(), buffer, buflen) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_GetDocPermissions(&self, document: FPDF_DOCUMENT) -> c_ulong {
-        unsafe { self.extern_FPDF_GetDocPermissions().unwrap()(document) }
+        unsafe { (self.extern_FPDF_GetDocPermissions)(document) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_GetSecurityHandlerRevision(&self, document: FPDF_DOCUMENT) -> c_int {
-        unsafe { self.extern_FPDF_GetSecurityHandlerRevision().unwrap()(document) }
+        unsafe { (self.extern_FPDF_GetSecurityHandlerRevision)(document) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_GetPageCount(&self, document: FPDF_DOCUMENT) -> c_int {
-        unsafe { self.extern_FPDF_GetPageCount().unwrap()(document) }
+        unsafe { (self.extern_FPDF_GetPageCount)(document) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_LoadPage(&self, document: FPDF_DOCUMENT, page_index: c_int) -> FPDF_PAGE {
-        unsafe { self.extern_FPDF_LoadPage().unwrap()(document, page_index) }
+        unsafe { (self.extern_FPDF_LoadPage)(document, page_index) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_ClosePage(&self, page: FPDF_PAGE) {
         unsafe {
-            self.extern_FPDF_ClosePage().unwrap()(page);
+            (self.extern_FPDF_ClosePage)(page);
         }
     }
 
@@ -5047,13 +1802,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         index: c_int,
     ) -> FPDF_BOOL {
         unsafe {
-            self.extern_FPDF_ImportPagesByIndex().unwrap()(
-                dest_doc,
-                src_doc,
-                page_indices,
-                length,
-                index,
-            )
+            (self.extern_FPDF_ImportPagesByIndex)(dest_doc, src_doc, page_indices, length, index)
         }
     }
 
@@ -5068,9 +1817,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     ) -> FPDF_BOOL {
         let c_pagerange = CString::new(pagerange).unwrap();
 
-        unsafe {
-            self.extern_FPDF_ImportPages().unwrap()(dest_doc, src_doc, c_pagerange.as_ptr(), index)
-        }
+        unsafe { (self.extern_FPDF_ImportPages)(dest_doc, src_doc, c_pagerange.as_ptr(), index) }
     }
 
     #[inline]
@@ -5084,7 +1831,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         num_pages_on_y_axis: size_t,
     ) -> FPDF_DOCUMENT {
         unsafe {
-            self.extern_FPDF_ImportNPagesToOne().unwrap()(
+            (self.extern_FPDF_ImportNPagesToOne)(
                 src_doc,
                 output_width,
                 output_height,
@@ -5097,13 +1844,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_GetPageWidthF(&self, page: FPDF_PAGE) -> c_float {
-        unsafe { self.extern_FPDF_GetPageWidthF().unwrap()(page) }
+        unsafe { (self.extern_FPDF_GetPageWidthF)(page) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_GetPageHeightF(&self, page: FPDF_PAGE) -> c_float {
-        unsafe { self.extern_FPDF_GetPageHeightF().unwrap()(page) }
+        unsafe { (self.extern_FPDF_GetPageHeightF)(page) }
     }
 
     #[inline]
@@ -5115,7 +1862,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_void,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDF_GetPageLabel().unwrap()(document, page_index, buffer, buflen) }
+        unsafe { (self.extern_FPDF_GetPageLabel)(document, page_index, buffer, buflen) }
     }
 
     #[inline]
@@ -5125,7 +1872,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         text_page: FPDF_TEXTPAGE,
         nTextIndex: c_int,
     ) -> c_int {
-        unsafe { self.extern_FPDFText_GetCharIndexFromTextIndex().unwrap()(text_page, nTextIndex) }
+        unsafe { (self.extern_FPDFText_GetCharIndexFromTextIndex)(text_page, nTextIndex) }
     }
 
     #[inline]
@@ -5135,19 +1882,19 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         text_page: FPDF_TEXTPAGE,
         nCharIndex: c_int,
     ) -> c_int {
-        unsafe { self.extern_FPDFText_GetTextIndexFromCharIndex().unwrap()(text_page, nCharIndex) }
+        unsafe { (self.extern_FPDFText_GetTextIndexFromCharIndex)(text_page, nCharIndex) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_GetSignatureCount(&self, document: FPDF_DOCUMENT) -> c_int {
-        unsafe { self.extern_FPDF_GetSignatureCount().unwrap()(document) }
+        unsafe { (self.extern_FPDF_GetSignatureCount)(document) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_GetSignatureObject(&self, document: FPDF_DOCUMENT, index: c_int) -> FPDF_SIGNATURE {
-        unsafe { self.extern_FPDF_GetSignatureObject().unwrap()(document, index) }
+        unsafe { (self.extern_FPDF_GetSignatureObject)(document, index) }
     }
 
     #[inline]
@@ -5158,7 +1905,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_void,
         length: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDFSignatureObj_GetContents().unwrap()(signature, buffer, length) }
+        unsafe { (self.extern_FPDFSignatureObj_GetContents)(signature, buffer, length) }
     }
 
     #[inline]
@@ -5169,7 +1916,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_int,
         length: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDFSignatureObj_GetByteRange().unwrap()(signature, buffer, length) }
+        unsafe { (self.extern_FPDFSignatureObj_GetByteRange)(signature, buffer, length) }
     }
 
     #[inline]
@@ -5180,7 +1927,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_char,
         length: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDFSignatureObj_GetSubFilter().unwrap()(signature, buffer, length) }
+        unsafe { (self.extern_FPDFSignatureObj_GetSubFilter)(signature, buffer, length) }
     }
 
     #[inline]
@@ -5191,7 +1938,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_void,
         length: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDFSignatureObj_GetReason().unwrap()(signature, buffer, length) }
+        unsafe { (self.extern_FPDFSignatureObj_GetReason)(signature, buffer, length) }
     }
 
     #[inline]
@@ -5202,31 +1949,31 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_char,
         length: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDFSignatureObj_GetTime().unwrap()(signature, buffer, length) }
+        unsafe { (self.extern_FPDFSignatureObj_GetTime)(signature, buffer, length) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFSignatureObj_GetDocMDPPermission(&self, signature: FPDF_SIGNATURE) -> c_uint {
-        unsafe { self.extern_FPDFSignatureObj_GetDocMDPPermission().unwrap()(signature) }
+        unsafe { (self.extern_FPDFSignatureObj_GetDocMDPPermission)(signature) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_StructTree_GetForPage(&self, page: FPDF_PAGE) -> FPDF_STRUCTTREE {
-        unsafe { self.extern_FPDF_StructTree_GetForPage().unwrap()(page) }
+        unsafe { (self.extern_FPDF_StructTree_GetForPage)(page) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_StructTree_Close(&self, struct_tree: FPDF_STRUCTTREE) {
-        unsafe { self.extern_FPDF_StructTree_Close().unwrap()(struct_tree) }
+        unsafe { (self.extern_FPDF_StructTree_Close)(struct_tree) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_StructTree_CountChildren(&self, struct_tree: FPDF_STRUCTTREE) -> c_int {
-        unsafe { self.extern_FPDF_StructTree_CountChildren().unwrap()(struct_tree) }
+        unsafe { (self.extern_FPDF_StructTree_CountChildren)(struct_tree) }
     }
 
     #[inline]
@@ -5236,7 +1983,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         struct_tree: FPDF_STRUCTTREE,
         index: c_int,
     ) -> FPDF_STRUCTELEMENT {
-        unsafe { self.extern_FPDF_StructTree_GetChildAtIndex().unwrap()(struct_tree, index) }
+        unsafe { (self.extern_FPDF_StructTree_GetChildAtIndex)(struct_tree, index) }
     }
 
     #[inline]
@@ -5247,9 +1994,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_void,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe {
-            self.extern_FPDF_StructElement_GetAltText().unwrap()(struct_element, buffer, buflen)
-        }
+        unsafe { (self.extern_FPDF_StructElement_GetAltText)(struct_element, buffer, buflen) }
     }
 
     #[inline]
@@ -5260,7 +2005,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_void,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDF_StructElement_GetID().unwrap()(struct_element, buffer, buflen) }
+        unsafe { (self.extern_FPDF_StructElement_GetID)(struct_element, buffer, buflen) }
     }
 
     #[inline]
@@ -5271,7 +2016,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_void,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDF_StructElement_GetLang().unwrap()(struct_element, buffer, buflen) }
+        unsafe { (self.extern_FPDF_StructElement_GetLang)(struct_element, buffer, buflen) }
     }
 
     #[inline]
@@ -5286,7 +2031,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         let c_attr_name = CString::new(attr_name).unwrap();
 
         unsafe {
-            self.extern_FPDF_StructElement_GetStringAttribute().unwrap()(
+            (self.extern_FPDF_StructElement_GetStringAttribute)(
                 struct_element,
                 c_attr_name.as_ptr(),
                 buffer,
@@ -5298,7 +2043,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_StructElement_GetMarkedContentID(&self, struct_element: FPDF_STRUCTELEMENT) -> c_int {
-        unsafe { self.extern_FPDF_StructElement_GetMarkedContentID().unwrap()(struct_element) }
+        unsafe { (self.extern_FPDF_StructElement_GetMarkedContentID)(struct_element) }
     }
 
     #[inline]
@@ -5309,7 +2054,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_void,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDF_StructElement_GetType().unwrap()(struct_element, buffer, buflen) }
+        unsafe { (self.extern_FPDF_StructElement_GetType)(struct_element, buffer, buflen) }
     }
 
     #[inline]
@@ -5320,15 +2065,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_void,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe {
-            self.extern_FPDF_StructElement_GetTitle().unwrap()(struct_element, buffer, buflen)
-        }
+        unsafe { (self.extern_FPDF_StructElement_GetTitle)(struct_element, buffer, buflen) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_StructElement_CountChildren(&self, struct_element: FPDF_STRUCTELEMENT) -> c_int {
-        unsafe { self.extern_FPDF_StructElement_CountChildren().unwrap()(struct_element) }
+        unsafe { (self.extern_FPDF_StructElement_CountChildren)(struct_element) }
     }
 
     #[inline]
@@ -5338,7 +2081,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         struct_element: FPDF_STRUCTELEMENT,
         index: c_int,
     ) -> FPDF_STRUCTELEMENT {
-        unsafe { self.extern_FPDF_StructElement_GetChildAtIndex().unwrap()(struct_element, index) }
+        unsafe { (self.extern_FPDF_StructElement_GetChildAtIndex)(struct_element, index) }
     }
 
     #[allow(non_snake_case)]
@@ -5349,36 +2092,41 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         width: c_double,
         height: c_double,
     ) -> FPDF_PAGE {
-        unsafe { self.extern_FPDFPage_New().unwrap()(document, page_index, width, height) }
+        unsafe { (self.extern_FPDFPage_New)(document, page_index, width, height) }
     }
 
     #[allow(non_snake_case)]
     fn FPDFPage_Delete(&self, document: FPDF_DOCUMENT, page_index: c_int) {
-        unsafe { self.extern_FPDFPage_Delete().unwrap()(document, page_index) }
+        unsafe { (self.extern_FPDFPage_Delete)(document, page_index) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPage_GetRotation(&self, page: FPDF_PAGE) -> c_int {
-        unsafe { self.extern_FPDFPage_GetRotation().unwrap()(page) }
+        unsafe { (self.extern_FPDFPage_GetRotation)(page) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPage_SetRotation(&self, page: FPDF_PAGE, rotate: c_int) {
-        unsafe { self.extern_FPDFPage_SetRotation().unwrap()(page, rotate) }
+        unsafe { (self.extern_FPDFPage_SetRotation)(page, rotate) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_GetPageBoundingBox(&self, page: FPDF_PAGE, rect: *mut FS_RECTF) -> FPDF_BOOL {
-        unsafe { self.extern_FPDF_GetPageBoundingBox().unwrap()(page, rect) }
+        unsafe { (self.extern_FPDF_GetPageBoundingBox)(page, rect) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
-    fn FPDF_GetPageSizeByIndexF(&self, document: FPDF_DOCUMENT, page_index: c_int, size: *mut FS_SIZEF) -> FPDF_BOOL {
-        unsafe { self.extern_FPDF_GetPageSizeByIndexF().unwrap()(document, page_index, size) }
+    fn FPDF_GetPageSizeByIndexF(
+        &self,
+        document: FPDF_DOCUMENT,
+        page_index: c_int,
+        size: *mut FS_SIZEF,
+    ) -> FPDF_BOOL {
+        unsafe { (self.extern_FPDF_GetPageSizeByIndexF)(document, page_index, size) }
     }
 
     #[inline]
@@ -5391,7 +2139,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         right: *mut c_float,
         top: *mut c_float,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPage_GetMediaBox().unwrap()(page, left, bottom, right, top) }
+        unsafe { (self.extern_FPDFPage_GetMediaBox)(page, left, bottom, right, top) }
     }
 
     #[inline]
@@ -5404,7 +2152,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         right: *mut c_float,
         top: *mut c_float,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPage_GetCropBox().unwrap()(page, left, bottom, right, top) }
+        unsafe { (self.extern_FPDFPage_GetCropBox)(page, left, bottom, right, top) }
     }
 
     #[inline]
@@ -5417,7 +2165,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         right: *mut c_float,
         top: *mut c_float,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPage_GetBleedBox().unwrap()(page, left, bottom, right, top) }
+        unsafe { (self.extern_FPDFPage_GetBleedBox)(page, left, bottom, right, top) }
     }
 
     #[inline]
@@ -5430,7 +2178,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         right: *mut c_float,
         top: *mut c_float,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPage_GetTrimBox().unwrap()(page, left, bottom, right, top) }
+        unsafe { (self.extern_FPDFPage_GetTrimBox)(page, left, bottom, right, top) }
     }
 
     #[inline]
@@ -5443,7 +2191,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         right: *mut c_float,
         top: *mut c_float,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPage_GetArtBox().unwrap()(page, left, bottom, right, top) }
+        unsafe { (self.extern_FPDFPage_GetArtBox)(page, left, bottom, right, top) }
     }
 
     #[inline]
@@ -5456,7 +2204,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         right: c_float,
         top: c_float,
     ) {
-        unsafe { self.extern_FPDFPage_SetMediaBox().unwrap()(page, left, bottom, right, top) }
+        unsafe { (self.extern_FPDFPage_SetMediaBox)(page, left, bottom, right, top) }
     }
 
     #[inline]
@@ -5469,7 +2217,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         right: c_float,
         top: c_float,
     ) {
-        unsafe { self.extern_FPDFPage_SetCropBox().unwrap()(page, left, bottom, right, top) }
+        unsafe { (self.extern_FPDFPage_SetCropBox)(page, left, bottom, right, top) }
     }
 
     #[inline]
@@ -5482,7 +2230,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         right: c_float,
         top: c_float,
     ) {
-        unsafe { self.extern_FPDFPage_SetBleedBox().unwrap()(page, left, bottom, right, top) }
+        unsafe { (self.extern_FPDFPage_SetBleedBox)(page, left, bottom, right, top) }
     }
 
     #[inline]
@@ -5495,7 +2243,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         right: c_float,
         top: c_float,
     ) {
-        unsafe { self.extern_FPDFPage_SetTrimBox().unwrap()(page, left, bottom, right, top) }
+        unsafe { (self.extern_FPDFPage_SetTrimBox)(page, left, bottom, right, top) }
     }
 
     #[inline]
@@ -5508,7 +2256,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         right: c_float,
         top: c_float,
     ) {
-        unsafe { self.extern_FPDFPage_SetArtBox().unwrap()(page, left, bottom, right, top) }
+        unsafe { (self.extern_FPDFPage_SetArtBox)(page, left, bottom, right, top) }
     }
 
     #[inline]
@@ -5519,7 +2267,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         matrix: *const FS_MATRIX,
         clipRect: *const FS_RECTF,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPage_TransFormWithClip().unwrap()(page, matrix, clipRect) }
+        unsafe { (self.extern_FPDFPage_TransFormWithClip)(page, matrix, clipRect) }
     }
 
     #[inline]
@@ -5534,27 +2282,25 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         e: f64,
         f: f64,
     ) {
-        unsafe {
-            self.extern_FPDFPageObj_TransformClipPath().unwrap()(page_object, a, b, c, d, e, f)
-        }
+        unsafe { (self.extern_FPDFPageObj_TransformClipPath)(page_object, a, b, c, d, e, f) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPageObj_GetClipPath(&self, page_object: FPDF_PAGEOBJECT) -> FPDF_CLIPPATH {
-        unsafe { self.extern_FPDFPageObj_GetClipPath().unwrap()(page_object) }
+        unsafe { (self.extern_FPDFPageObj_GetClipPath)(page_object) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFClipPath_CountPaths(&self, clip_path: FPDF_CLIPPATH) -> c_int {
-        unsafe { self.extern_FPDFClipPath_CountPaths().unwrap()(clip_path) }
+        unsafe { (self.extern_FPDFClipPath_CountPaths)(clip_path) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFClipPath_CountPathSegments(&self, clip_path: FPDF_CLIPPATH, path_index: c_int) -> c_int {
-        unsafe { self.extern_FPDFClipPath_CountPathSegments().unwrap()(clip_path, path_index) }
+        unsafe { (self.extern_FPDFClipPath_CountPathSegments)(clip_path, path_index) }
     }
 
     #[inline]
@@ -5565,39 +2311,37 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         path_index: c_int,
         segment_index: c_int,
     ) -> FPDF_PATHSEGMENT {
-        unsafe {
-            self.extern_FPDFClipPath_GetPathSegment().unwrap()(clip_path, path_index, segment_index)
-        }
+        unsafe { (self.extern_FPDFClipPath_GetPathSegment)(clip_path, path_index, segment_index) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_CreateClipPath(&self, left: f32, bottom: f32, right: f32, top: f32) -> FPDF_CLIPPATH {
-        unsafe { self.extern_FPDF_CreateClipPath().unwrap()(left, bottom, right, top) }
+        unsafe { (self.extern_FPDF_CreateClipPath)(left, bottom, right, top) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_DestroyClipPath(&self, clipPath: FPDF_CLIPPATH) {
-        unsafe { self.extern_FPDF_DestroyClipPath().unwrap()(clipPath) }
+        unsafe { (self.extern_FPDF_DestroyClipPath)(clipPath) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPage_InsertClipPath(&self, page: FPDF_PAGE, clipPath: FPDF_CLIPPATH) {
-        unsafe { self.extern_FPDFPage_InsertClipPath().unwrap()(page, clipPath) }
+        unsafe { (self.extern_FPDFPage_InsertClipPath)(page, clipPath) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPage_HasTransparency(&self, page: FPDF_PAGE) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPage_HasTransparency().unwrap()(page) }
+        unsafe { (self.extern_FPDFPage_HasTransparency)(page) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPage_GenerateContent(&self, page: FPDF_PAGE) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPage_GenerateContent().unwrap()(page) }
+        unsafe { (self.extern_FPDFPage_GenerateContent)(page) }
     }
 
     #[inline]
@@ -5610,21 +2354,19 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         first_scan: *mut c_void,
         stride: c_int,
     ) -> FPDF_BITMAP {
-        unsafe {
-            self.extern_FPDFBitmap_CreateEx().unwrap()(width, height, format, first_scan, stride)
-        }
+        unsafe { (self.extern_FPDFBitmap_CreateEx)(width, height, format, first_scan, stride) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFBitmap_Destroy(&self, bitmap: FPDF_BITMAP) {
-        unsafe { self.extern_FPDFBitmap_Destroy().unwrap()(bitmap) }
+        unsafe { (self.extern_FPDFBitmap_Destroy)(bitmap) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFBitmap_GetFormat(&self, bitmap: FPDF_BITMAP) -> c_int {
-        unsafe { self.extern_FPDFBitmap_GetFormat().unwrap()(bitmap) }
+        unsafe { (self.extern_FPDFBitmap_GetFormat)(bitmap) }
     }
 
     #[inline]
@@ -5639,32 +2381,32 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         color: FPDF_DWORD,
     ) {
         unsafe {
-            self.extern_FPDFBitmap_FillRect().unwrap()(bitmap, left, top, width, height, color);
+            (self.extern_FPDFBitmap_FillRect)(bitmap, left, top, width, height, color);
         }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFBitmap_GetBuffer(&self, bitmap: FPDF_BITMAP) -> *mut c_void {
-        unsafe { self.extern_FPDFBitmap_GetBuffer().unwrap()(bitmap) }
+        unsafe { (self.extern_FPDFBitmap_GetBuffer)(bitmap) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFBitmap_GetWidth(&self, bitmap: FPDF_BITMAP) -> c_int {
-        unsafe { self.extern_FPDFBitmap_GetWidth().unwrap()(bitmap) }
+        unsafe { (self.extern_FPDFBitmap_GetWidth)(bitmap) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFBitmap_GetHeight(&self, bitmap: FPDF_BITMAP) -> c_int {
-        unsafe { self.extern_FPDFBitmap_GetHeight().unwrap()(bitmap) }
+        unsafe { (self.extern_FPDFBitmap_GetHeight)(bitmap) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFBitmap_GetStride(&self, bitmap: FPDF_BITMAP) -> c_int {
-        unsafe { self.extern_FPDFBitmap_GetStride().unwrap()(bitmap) }
+        unsafe { (self.extern_FPDFBitmap_GetStride)(bitmap) }
     }
 
     #[inline]
@@ -5681,7 +2423,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         flags: c_int,
     ) {
         unsafe {
-            self.extern_FPDF_RenderPageBitmap().unwrap()(
+            (self.extern_FPDF_RenderPageBitmap)(
                 bitmap, page, start_x, start_y, size_x, size_y, rotate, flags,
             );
         }
@@ -5698,16 +2440,14 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         flags: c_int,
     ) {
         unsafe {
-            self.extern_FPDF_RenderPageBitmapWithMatrix().unwrap()(
-                bitmap, page, matrix, clipping, flags,
-            );
+            (self.extern_FPDF_RenderPageBitmapWithMatrix)(bitmap, page, matrix, clipping, flags);
         }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_IsSupportedSubtype(&self, subtype: FPDF_ANNOTATION_SUBTYPE) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_IsSupportedSubtype().unwrap()(subtype) }
+        unsafe { (self.extern_FPDFAnnot_IsSupportedSubtype)(subtype) }
     }
 
     #[inline]
@@ -5717,55 +2457,55 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         page: FPDF_PAGE,
         subtype: FPDF_ANNOTATION_SUBTYPE,
     ) -> FPDF_ANNOTATION {
-        unsafe { self.extern_FPDFPage_CreateAnnot().unwrap()(page, subtype) }
+        unsafe { (self.extern_FPDFPage_CreateAnnot)(page, subtype) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPage_GetAnnotCount(&self, page: FPDF_PAGE) -> c_int {
-        unsafe { self.extern_FPDFPage_GetAnnotCount().unwrap()(page) }
+        unsafe { (self.extern_FPDFPage_GetAnnotCount)(page) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPage_GetAnnot(&self, page: FPDF_PAGE, index: c_int) -> FPDF_ANNOTATION {
-        unsafe { self.extern_FPDFPage_GetAnnot().unwrap()(page, index) }
+        unsafe { (self.extern_FPDFPage_GetAnnot)(page, index) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPage_GetAnnotIndex(&self, page: FPDF_PAGE, annot: FPDF_ANNOTATION) -> c_int {
-        unsafe { self.extern_FPDFPage_GetAnnotIndex().unwrap()(page, annot) }
+        unsafe { (self.extern_FPDFPage_GetAnnotIndex)(page, annot) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPage_CloseAnnot(&self, annot: FPDF_ANNOTATION) {
-        unsafe { self.extern_FPDFPage_CloseAnnot().unwrap()(annot) }
+        unsafe { (self.extern_FPDFPage_CloseAnnot)(annot) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPage_RemoveAnnot(&self, page: FPDF_PAGE, index: c_int) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPage_RemoveAnnot().unwrap()(page, index) }
+        unsafe { (self.extern_FPDFPage_RemoveAnnot)(page, index) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_GetSubtype(&self, annot: FPDF_ANNOTATION) -> FPDF_ANNOTATION_SUBTYPE {
-        unsafe { self.extern_FPDFAnnot_GetSubtype().unwrap()(annot) }
+        unsafe { (self.extern_FPDFAnnot_GetSubtype)(annot) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_IsObjectSupportedSubtype(&self, subtype: FPDF_ANNOTATION_SUBTYPE) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_IsObjectSupportedSubtype().unwrap()(subtype) }
+        unsafe { (self.extern_FPDFAnnot_IsObjectSupportedSubtype)(subtype) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_UpdateObject(&self, annot: FPDF_ANNOTATION, obj: FPDF_PAGEOBJECT) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_UpdateObject().unwrap()(annot, obj) }
+        unsafe { (self.extern_FPDFAnnot_UpdateObject)(annot, obj) }
     }
 
     #[inline]
@@ -5776,37 +2516,37 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         points: *const FS_POINTF,
         point_count: size_t,
     ) -> c_int {
-        unsafe { self.extern_FPDFAnnot_AddInkStroke().unwrap()(annot, points, point_count) }
+        unsafe { (self.extern_FPDFAnnot_AddInkStroke)(annot, points, point_count) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_RemoveInkList(&self, annot: FPDF_ANNOTATION) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_RemoveInkList().unwrap()(annot) }
+        unsafe { (self.extern_FPDFAnnot_RemoveInkList)(annot) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_AppendObject(&self, annot: FPDF_ANNOTATION, obj: FPDF_PAGEOBJECT) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_AppendObject().unwrap()(annot, obj) }
+        unsafe { (self.extern_FPDFAnnot_AppendObject)(annot, obj) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_GetObjectCount(&self, annot: FPDF_ANNOTATION) -> c_int {
-        unsafe { self.extern_FPDFAnnot_GetObjectCount().unwrap()(annot) }
+        unsafe { (self.extern_FPDFAnnot_GetObjectCount)(annot) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_GetObject(&self, annot: FPDF_ANNOTATION, index: c_int) -> FPDF_PAGEOBJECT {
-        unsafe { self.extern_FPDFAnnot_GetObject().unwrap()(annot, index) }
+        unsafe { (self.extern_FPDFAnnot_GetObject)(annot, index) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_RemoveObject(&self, annot: FPDF_ANNOTATION, index: c_int) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_RemoveObject().unwrap()(annot, index) }
+        unsafe { (self.extern_FPDFAnnot_RemoveObject)(annot, index) }
     }
 
     #[inline]
@@ -5820,7 +2560,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         B: c_uint,
         A: c_uint,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_SetColor().unwrap()(annot, color_type, R, G, B, A) }
+        unsafe { (self.extern_FPDFAnnot_SetColor)(annot, color_type, R, G, B, A) }
     }
 
     #[inline]
@@ -5834,13 +2574,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         B: *mut c_uint,
         A: *mut c_uint,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_GetColor().unwrap()(annot, color_type, R, G, B, A) }
+        unsafe { (self.extern_FPDFAnnot_GetColor)(annot, color_type, R, G, B, A) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_HasAttachmentPoints(&self, annot: FPDF_ANNOTATION) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_HasAttachmentPoints().unwrap()(annot) }
+        unsafe { (self.extern_FPDFAnnot_HasAttachmentPoints)(annot) }
     }
 
     #[inline]
@@ -5851,9 +2591,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         quad_index: size_t,
         quad_points: *const FS_QUADPOINTSF,
     ) -> FPDF_BOOL {
-        unsafe {
-            self.extern_FPDFAnnot_SetAttachmentPoints().unwrap()(annot, quad_index, quad_points)
-        }
+        unsafe { (self.extern_FPDFAnnot_SetAttachmentPoints)(annot, quad_index, quad_points) }
     }
 
     #[inline]
@@ -5863,13 +2601,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         annot: FPDF_ANNOTATION,
         quad_points: *const FS_QUADPOINTSF,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_AppendAttachmentPoints().unwrap()(annot, quad_points) }
+        unsafe { (self.extern_FPDFAnnot_AppendAttachmentPoints)(annot, quad_points) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_CountAttachmentPoints(&self, annot: FPDF_ANNOTATION) -> size_t {
-        unsafe { self.extern_FPDFAnnot_CountAttachmentPoints().unwrap()(annot) }
+        unsafe { (self.extern_FPDFAnnot_CountAttachmentPoints)(annot) }
     }
 
     #[inline]
@@ -5880,21 +2618,19 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         quad_index: size_t,
         quad_points: *mut FS_QUADPOINTSF,
     ) -> FPDF_BOOL {
-        unsafe {
-            self.extern_FPDFAnnot_GetAttachmentPoints().unwrap()(annot, quad_index, quad_points)
-        }
+        unsafe { (self.extern_FPDFAnnot_GetAttachmentPoints)(annot, quad_index, quad_points) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_SetRect(&self, annot: FPDF_ANNOTATION, rect: *const FS_RECTF) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_SetRect().unwrap()(annot, rect) }
+        unsafe { (self.extern_FPDFAnnot_SetRect)(annot, rect) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_GetRect(&self, annot: FPDF_ANNOTATION, rect: *mut FS_RECTF) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_GetRect().unwrap()(annot, rect) }
+        unsafe { (self.extern_FPDFAnnot_GetRect)(annot, rect) }
     }
 
     #[inline]
@@ -5905,13 +2641,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut FS_POINTF,
         length: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDFAnnot_GetVertices().unwrap()(annot, buffer, length) }
+        unsafe { (self.extern_FPDFAnnot_GetVertices)(annot, buffer, length) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_GetInkListCount(&self, annot: FPDF_ANNOTATION) -> c_ulong {
-        unsafe { self.extern_FPDFAnnot_GetInkListCount().unwrap()(annot) }
+        unsafe { (self.extern_FPDFAnnot_GetInkListCount)(annot) }
     }
 
     #[inline]
@@ -5923,9 +2659,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut FS_POINTF,
         length: c_ulong,
     ) -> c_ulong {
-        unsafe {
-            self.extern_FPDFAnnot_GetInkListPath().unwrap()(annot, path_index, buffer, length)
-        }
+        unsafe { (self.extern_FPDFAnnot_GetInkListPath)(annot, path_index, buffer, length) }
     }
 
     #[inline]
@@ -5936,7 +2670,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         start: *mut FS_POINTF,
         end: *mut FS_POINTF,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_GetLine().unwrap()(annot, start, end) }
+        unsafe { (self.extern_FPDFAnnot_GetLine)(annot, start, end) }
     }
 
     #[inline]
@@ -5949,7 +2683,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         border_width: f32,
     ) -> FPDF_BOOL {
         unsafe {
-            self.extern_FPDFAnnot_SetBorder().unwrap()(
+            (self.extern_FPDFAnnot_SetBorder)(
                 annot,
                 horizontal_radius,
                 vertical_radius,
@@ -5968,7 +2702,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         border_width: *mut f32,
     ) -> FPDF_BOOL {
         unsafe {
-            self.extern_FPDFAnnot_GetBorder().unwrap()(
+            (self.extern_FPDFAnnot_GetBorder)(
                 annot,
                 horizontal_radius,
                 vertical_radius,
@@ -5982,7 +2716,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     fn FPDFAnnot_HasKey(&self, annot: FPDF_ANNOTATION, key: &str) -> FPDF_BOOL {
         let c_key = CString::new(key).unwrap();
 
-        unsafe { self.extern_FPDFAnnot_HasKey().unwrap()(annot, c_key.as_ptr()) }
+        unsafe { (self.extern_FPDFAnnot_HasKey)(annot, c_key.as_ptr()) }
     }
 
     #[inline]
@@ -5990,7 +2724,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     fn FPDFAnnot_GetValueType(&self, annot: FPDF_ANNOTATION, key: &str) -> FPDF_OBJECT_TYPE {
         let c_key = CString::new(key).unwrap();
 
-        unsafe { self.extern_FPDFAnnot_GetValueType().unwrap()(annot, c_key.as_ptr()) }
+        unsafe { (self.extern_FPDFAnnot_GetValueType)(annot, c_key.as_ptr()) }
     }
 
     #[inline]
@@ -6003,7 +2737,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     ) -> FPDF_BOOL {
         let c_key = CString::new(key).unwrap();
 
-        unsafe { self.extern_FPDFAnnot_SetStringValue().unwrap()(annot, c_key.as_ptr(), value) }
+        unsafe { (self.extern_FPDFAnnot_SetStringValue)(annot, c_key.as_ptr(), value) }
     }
 
     #[inline]
@@ -6017,9 +2751,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     ) -> c_ulong {
         let c_key = CString::new(key).unwrap();
 
-        unsafe {
-            self.extern_FPDFAnnot_GetStringValue().unwrap()(annot, c_key.as_ptr(), buffer, buflen)
-        }
+        unsafe { (self.extern_FPDFAnnot_GetStringValue)(annot, c_key.as_ptr(), buffer, buflen) }
     }
 
     #[inline]
@@ -6032,7 +2764,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     ) -> FPDF_BOOL {
         let c_key = CString::new(key).unwrap();
 
-        unsafe { self.extern_FPDFAnnot_GetNumberValue().unwrap()(annot, c_key.as_ptr(), value) }
+        unsafe { (self.extern_FPDFAnnot_GetNumberValue)(annot, c_key.as_ptr(), value) }
     }
 
     #[inline]
@@ -6043,7 +2775,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         appearanceMode: FPDF_ANNOT_APPEARANCEMODE,
         value: FPDF_WIDESTRING,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_SetAP().unwrap()(annot, appearanceMode, value) }
+        unsafe { (self.extern_FPDFAnnot_SetAP)(annot, appearanceMode, value) }
     }
 
     #[inline]
@@ -6055,7 +2787,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut FPDF_WCHAR,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDFAnnot_GetAP().unwrap()(annot, appearanceMode, buffer, buflen) }
+        unsafe { (self.extern_FPDFAnnot_GetAP)(annot, appearanceMode, buffer, buflen) }
     }
 
     #[inline]
@@ -6063,19 +2795,19 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     fn FPDFAnnot_GetLinkedAnnot(&self, annot: FPDF_ANNOTATION, key: &str) -> FPDF_ANNOTATION {
         let c_key = CString::new(key).unwrap();
 
-        unsafe { self.extern_FPDFAnnot_GetLinkedAnnot().unwrap()(annot, c_key.as_ptr()) }
+        unsafe { (self.extern_FPDFAnnot_GetLinkedAnnot)(annot, c_key.as_ptr()) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_GetFlags(&self, annot: FPDF_ANNOTATION) -> c_int {
-        unsafe { self.extern_FPDFAnnot_GetFlags().unwrap()(annot) }
+        unsafe { (self.extern_FPDFAnnot_GetFlags)(annot) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_SetFlags(&self, annot: FPDF_ANNOTATION, flags: c_int) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_SetFlags().unwrap()(annot, flags) }
+        unsafe { (self.extern_FPDFAnnot_SetFlags)(annot, flags) }
     }
 
     #[inline]
@@ -6085,7 +2817,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         handle: FPDF_FORMHANDLE,
         annot: FPDF_ANNOTATION,
     ) -> c_int {
-        unsafe { self.extern_FPDFAnnot_GetFormFieldFlags().unwrap()(handle, annot) }
+        unsafe { (self.extern_FPDFAnnot_GetFormFieldFlags)(handle, annot) }
     }
 
     #[inline]
@@ -6096,7 +2828,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         page: FPDF_PAGE,
         point: *const FS_POINTF,
     ) -> FPDF_ANNOTATION {
-        unsafe { self.extern_FPDFAnnot_GetFormFieldAtPoint().unwrap()(hHandle, page, point) }
+        unsafe { (self.extern_FPDFAnnot_GetFormFieldAtPoint)(hHandle, page, point) }
     }
 
     #[inline]
@@ -6108,7 +2840,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut FPDF_WCHAR,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDFAnnot_GetFormFieldName().unwrap()(hHandle, annot, buffer, buflen) }
+        unsafe { (self.extern_FPDFAnnot_GetFormFieldName)(hHandle, annot, buffer, buflen) }
     }
 
     #[inline]
@@ -6118,7 +2850,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         hHandle: FPDF_FORMHANDLE,
         annot: FPDF_ANNOTATION,
     ) -> c_int {
-        unsafe { self.extern_FPDFAnnot_GetFormFieldType().unwrap()(hHandle, annot) }
+        unsafe { (self.extern_FPDFAnnot_GetFormFieldType)(hHandle, annot) }
     }
 
     #[inline]
@@ -6130,15 +2862,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut FPDF_WCHAR,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe {
-            self.extern_FPDFAnnot_GetFormFieldValue().unwrap()(hHandle, annot, buffer, buflen)
-        }
+        unsafe { (self.extern_FPDFAnnot_GetFormFieldValue)(hHandle, annot, buffer, buflen) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_GetOptionCount(&self, hHandle: FPDF_FORMHANDLE, annot: FPDF_ANNOTATION) -> c_int {
-        unsafe { self.extern_FPDFAnnot_GetOptionCount().unwrap()(hHandle, annot) }
+        unsafe { (self.extern_FPDFAnnot_GetOptionCount)(hHandle, annot) }
     }
 
     #[inline]
@@ -6151,9 +2881,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut FPDF_WCHAR,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe {
-            self.extern_FPDFAnnot_GetOptionLabel().unwrap()(hHandle, annot, index, buffer, buflen)
-        }
+        unsafe { (self.extern_FPDFAnnot_GetOptionLabel)(hHandle, annot, index, buffer, buflen) }
     }
 
     #[inline]
@@ -6164,7 +2892,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         annot: FPDF_ANNOTATION,
         index: c_int,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_IsOptionSelected().unwrap()(handle, annot, index) }
+        unsafe { (self.extern_FPDFAnnot_IsOptionSelected)(handle, annot, index) }
     }
 
     #[inline]
@@ -6175,13 +2903,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         annot: FPDF_ANNOTATION,
         value: *mut f32,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_GetFontSize().unwrap()(hHandle, annot, value) }
+        unsafe { (self.extern_FPDFAnnot_GetFontSize)(hHandle, annot, value) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_IsChecked(&self, hHandle: FPDF_FORMHANDLE, annot: FPDF_ANNOTATION) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_IsChecked().unwrap()(hHandle, annot) }
+        unsafe { (self.extern_FPDFAnnot_IsChecked)(hHandle, annot) }
     }
 
     #[inline]
@@ -6192,13 +2920,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         subtypes: *const FPDF_ANNOTATION_SUBTYPE,
         count: size_t,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_SetFocusableSubtypes().unwrap()(hHandle, subtypes, count) }
+        unsafe { (self.extern_FPDFAnnot_SetFocusableSubtypes)(hHandle, subtypes, count) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_GetFocusableSubtypesCount(&self, hHandle: FPDF_FORMHANDLE) -> c_int {
-        unsafe { self.extern_FPDFAnnot_GetFocusableSubtypesCount().unwrap()(hHandle) }
+        unsafe { (self.extern_FPDFAnnot_GetFocusableSubtypesCount)(hHandle) }
     }
 
     #[inline]
@@ -6209,13 +2937,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         subtypes: *mut FPDF_ANNOTATION_SUBTYPE,
         count: size_t,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFAnnot_GetFocusableSubtypes().unwrap()(hHandle, subtypes, count) }
+        unsafe { (self.extern_FPDFAnnot_GetFocusableSubtypes)(hHandle, subtypes, count) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAnnot_GetLink(&self, annot: FPDF_ANNOTATION) -> FPDF_LINK {
-        unsafe { self.extern_FPDFAnnot_GetLink().unwrap()(annot) }
+        unsafe { (self.extern_FPDFAnnot_GetLink)(annot) }
     }
 
     #[inline]
@@ -6225,7 +2953,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         hHandle: FPDF_FORMHANDLE,
         annot: FPDF_ANNOTATION,
     ) -> c_int {
-        unsafe { self.extern_FPDFAnnot_GetFormControlCount().unwrap()(hHandle, annot) }
+        unsafe { (self.extern_FPDFAnnot_GetFormControlCount)(hHandle, annot) }
     }
 
     #[inline]
@@ -6235,7 +2963,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         hHandle: FPDF_FORMHANDLE,
         annot: FPDF_ANNOTATION,
     ) -> c_int {
-        unsafe { self.extern_FPDFAnnot_GetFormControlIndex().unwrap()(hHandle, annot) }
+        unsafe { (self.extern_FPDFAnnot_GetFormControlIndex)(hHandle, annot) }
     }
 
     #[inline]
@@ -6247,9 +2975,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut FPDF_WCHAR,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe {
-            self.extern_FPDFAnnot_GetFormFieldExportValue().unwrap()(hHandle, annot, buffer, buflen)
-        }
+        unsafe { (self.extern_FPDFAnnot_GetFormFieldExportValue)(hHandle, annot, buffer, buflen) }
     }
 
     #[inline]
@@ -6257,7 +2983,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     fn FPDFAnnot_SetURI(&self, annot: FPDF_ANNOTATION, uri: &str) -> FPDF_BOOL {
         let c_uri = CString::new(uri).unwrap();
 
-        unsafe { self.extern_FPDFAnnot_SetURI().unwrap()(annot, c_uri.as_ptr()) }
+        unsafe { (self.extern_FPDFAnnot_SetURI)(annot, c_uri.as_ptr()) }
     }
 
     #[inline]
@@ -6267,14 +2993,14 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         document: FPDF_DOCUMENT,
         form_info: *mut FPDF_FORMFILLINFO,
     ) -> FPDF_FORMHANDLE {
-        unsafe { self.extern_FPDFDOC_InitFormFillEnvironment().unwrap()(document, form_info) }
+        unsafe { (self.extern_FPDFDOC_InitFormFillEnvironment)(document, form_info) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFDOC_ExitFormFillEnvironment(&self, handle: FPDF_FORMHANDLE) {
         unsafe {
-            self.extern_FPDFDOC_ExitFormFillEnvironment().unwrap()(handle);
+            (self.extern_FPDFDOC_ExitFormFillEnvironment)(handle);
         }
     }
 
@@ -6282,7 +3008,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     #[allow(non_snake_case)]
     fn FORM_OnAfterLoadPage(&self, page: FPDF_PAGE, handle: FPDF_FORMHANDLE) {
         unsafe {
-            self.extern_FORM_OnAfterLoadPage().unwrap()(page, handle);
+            (self.extern_FORM_OnAfterLoadPage)(page, handle);
         }
     }
 
@@ -6290,20 +3016,20 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     #[allow(non_snake_case)]
     fn FORM_OnBeforeClosePage(&self, page: FPDF_PAGE, handle: FPDF_FORMHANDLE) {
         unsafe {
-            self.extern_FORM_OnBeforeClosePage().unwrap()(page, handle);
+            (self.extern_FORM_OnBeforeClosePage)(page, handle);
         }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFDoc_GetPageMode(&self, document: FPDF_DOCUMENT) -> c_int {
-        unsafe { self.extern_FPDFDoc_GetPageMode().unwrap()(document) }
+        unsafe { (self.extern_FPDFDoc_GetPageMode)(document) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPage_Flatten(&self, page: FPDF_PAGE, nFlag: c_int) -> c_int {
-        unsafe { self.extern_FPDFPage_Flatten().unwrap()(page, nFlag) }
+        unsafe { (self.extern_FPDFPage_Flatten)(page, nFlag) }
     }
 
     #[inline]
@@ -6315,7 +3041,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         color: FPDF_DWORD,
     ) {
         unsafe {
-            self.extern_FPDF_SetFormFieldHighlightColor().unwrap()(handle, field_type, color);
+            (self.extern_FPDF_SetFormFieldHighlightColor)(handle, field_type, color);
         }
     }
 
@@ -6323,7 +3049,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     #[allow(non_snake_case)]
     fn FPDF_SetFormFieldHighlightAlpha(&self, handle: FPDF_FORMHANDLE, alpha: c_uchar) {
         unsafe {
-            self.extern_FPDF_SetFormFieldHighlightAlpha().unwrap()(handle, alpha);
+            (self.extern_FPDF_SetFormFieldHighlightAlpha)(handle, alpha);
         }
     }
 
@@ -6342,7 +3068,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         flags: c_int,
     ) {
         unsafe {
-            self.extern_FPDF_FFLDraw().unwrap()(
+            (self.extern_FPDF_FFLDraw)(
                 handle, bitmap, page, start_x, start_y, size_x, size_y, rotate, flags,
             );
         }
@@ -6355,7 +3081,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         document: FPDF_DOCUMENT,
         bookmark: FPDF_BOOKMARK,
     ) -> FPDF_BOOKMARK {
-        unsafe { self.extern_FPDFBookmark_GetFirstChild().unwrap()(document, bookmark) }
+        unsafe { (self.extern_FPDFBookmark_GetFirstChild)(document, bookmark) }
     }
 
     #[inline]
@@ -6365,7 +3091,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         document: FPDF_DOCUMENT,
         bookmark: FPDF_BOOKMARK,
     ) -> FPDF_BOOKMARK {
-        unsafe { self.extern_FPDFBookmark_GetNextSibling().unwrap()(document, bookmark) }
+        unsafe { (self.extern_FPDFBookmark_GetNextSibling)(document, bookmark) }
     }
 
     #[inline]
@@ -6376,43 +3102,43 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_void,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDFBookmark_GetTitle().unwrap()(bookmark, buffer, buflen) }
+        unsafe { (self.extern_FPDFBookmark_GetTitle)(bookmark, buffer, buflen) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFBookmark_GetCount(&self, bookmark: FPDF_BOOKMARK) -> c_int {
-        unsafe { self.extern_FPDFBookmark_GetCount().unwrap()(bookmark) }
+        unsafe { (self.extern_FPDFBookmark_GetCount)(bookmark) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFBookmark_Find(&self, document: FPDF_DOCUMENT, title: FPDF_WIDESTRING) -> FPDF_BOOKMARK {
-        unsafe { self.extern_FPDFBookmark_Find().unwrap()(document, title) }
+        unsafe { (self.extern_FPDFBookmark_Find)(document, title) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFBookmark_GetDest(&self, document: FPDF_DOCUMENT, bookmark: FPDF_BOOKMARK) -> FPDF_DEST {
-        unsafe { self.extern_FPDFBookmark_GetDest().unwrap()(document, bookmark) }
+        unsafe { (self.extern_FPDFBookmark_GetDest)(document, bookmark) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFBookmark_GetAction(&self, bookmark: FPDF_BOOKMARK) -> FPDF_ACTION {
-        unsafe { self.extern_FPDFBookmark_GetAction().unwrap()(bookmark) }
+        unsafe { (self.extern_FPDFBookmark_GetAction)(bookmark) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAction_GetType(&self, action: FPDF_ACTION) -> c_ulong {
-        unsafe { self.extern_FPDFAction_GetType().unwrap()(action) }
+        unsafe { (self.extern_FPDFAction_GetType)(action) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFAction_GetDest(&self, document: FPDF_DOCUMENT, action: FPDF_ACTION) -> FPDF_DEST {
-        unsafe { self.extern_FPDFAction_GetDest().unwrap()(document, action) }
+        unsafe { (self.extern_FPDFAction_GetDest)(document, action) }
     }
 
     #[inline]
@@ -6423,7 +3149,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_void,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDFAction_GetFilePath().unwrap()(action, buffer, buflen) }
+        unsafe { (self.extern_FPDFAction_GetFilePath)(action, buffer, buflen) }
     }
 
     #[inline]
@@ -6435,13 +3161,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_void,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDFAction_GetURIPath().unwrap()(document, action, buffer, buflen) }
+        unsafe { (self.extern_FPDFAction_GetURIPath)(document, action, buffer, buflen) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFDest_GetDestPageIndex(&self, document: FPDF_DOCUMENT, dest: FPDF_DEST) -> c_int {
-        unsafe { self.extern_FPDFDest_GetDestPageIndex().unwrap()(document, dest) }
+        unsafe { (self.extern_FPDFDest_GetDestPageIndex)(document, dest) }
     }
 
     #[inline]
@@ -6452,7 +3178,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         pNumParams: *mut c_ulong,
         pParams: *mut FS_FLOAT,
     ) -> c_ulong {
-        unsafe { self.extern_FPDFDest_GetView().unwrap()(dest, pNumParams, pParams) }
+        unsafe { (self.extern_FPDFDest_GetView)(dest, pNumParams, pParams) }
     }
 
     #[inline]
@@ -6469,34 +3195,32 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         zoom: *mut FS_FLOAT,
     ) -> FPDF_BOOL {
         unsafe {
-            self.extern_FPDFDest_GetLocationInPage().unwrap()(
-                dest, hasXVal, hasYVal, hasZoomVal, x, y, zoom,
-            )
+            (self.extern_FPDFDest_GetLocationInPage)(dest, hasXVal, hasYVal, hasZoomVal, x, y, zoom)
         }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFLink_GetLinkAtPoint(&self, page: FPDF_PAGE, x: c_double, y: c_double) -> FPDF_LINK {
-        unsafe { self.extern_FPDFLink_GetLinkAtPoint().unwrap()(page, x, y) }
+        unsafe { (self.extern_FPDFLink_GetLinkAtPoint)(page, x, y) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFLink_GetLinkZOrderAtPoint(&self, page: FPDF_PAGE, x: c_double, y: c_double) -> c_int {
-        unsafe { self.extern_FPDFLink_GetLinkZOrderAtPoint().unwrap()(page, x, y) }
+        unsafe { (self.extern_FPDFLink_GetLinkZOrderAtPoint)(page, x, y) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFLink_GetDest(&self, document: FPDF_DOCUMENT, link: FPDF_LINK) -> FPDF_DEST {
-        unsafe { self.extern_FPDFLink_GetDest().unwrap()(document, link) }
+        unsafe { (self.extern_FPDFLink_GetDest)(document, link) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFLink_GetAction(&self, link: FPDF_LINK) -> FPDF_ACTION {
-        unsafe { self.extern_FPDFLink_GetAction().unwrap()(link) }
+        unsafe { (self.extern_FPDFLink_GetAction)(link) }
     }
 
     #[inline]
@@ -6507,25 +3231,25 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         start_pos: *mut c_int,
         link_annot: *mut FPDF_LINK,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFLink_Enumerate().unwrap()(page, start_pos, link_annot) }
+        unsafe { (self.extern_FPDFLink_Enumerate)(page, start_pos, link_annot) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFLink_GetAnnot(&self, page: FPDF_PAGE, link_annot: FPDF_LINK) -> FPDF_ANNOTATION {
-        unsafe { self.extern_FPDFLink_GetAnnot().unwrap()(page, link_annot) }
+        unsafe { (self.extern_FPDFLink_GetAnnot)(page, link_annot) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFLink_GetAnnotRect(&self, link_annot: FPDF_LINK, rect: *mut FS_RECTF) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFLink_GetAnnotRect().unwrap()(link_annot, rect) }
+        unsafe { (self.extern_FPDFLink_GetAnnotRect)(link_annot, rect) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFLink_CountQuadPoints(&self, link_annot: FPDF_LINK) -> c_int {
-        unsafe { self.extern_FPDFLink_CountQuadPoints().unwrap()(link_annot) }
+        unsafe { (self.extern_FPDFLink_CountQuadPoints)(link_annot) }
     }
 
     #[inline]
@@ -6536,45 +3260,43 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         quad_index: c_int,
         quad_points: *mut FS_QUADPOINTSF,
     ) -> FPDF_BOOL {
-        unsafe {
-            self.extern_FPDFLink_GetQuadPoints().unwrap()(link_annot, quad_index, quad_points)
-        }
+        unsafe { (self.extern_FPDFLink_GetQuadPoints)(link_annot, quad_index, quad_points) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_GetPageAAction(&self, page: FPDF_PAGE, aa_type: c_int) -> FPDF_ACTION {
-        unsafe { self.extern_FPDF_GetPageAAction().unwrap()(page, aa_type) }
+        unsafe { (self.extern_FPDF_GetPageAAction)(page, aa_type) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFText_LoadPage(&self, page: FPDF_PAGE) -> FPDF_TEXTPAGE {
-        unsafe { self.extern_FPDFText_LoadPage().unwrap()(page) }
+        unsafe { (self.extern_FPDFText_LoadPage)(page) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFText_ClosePage(&self, text_page: FPDF_TEXTPAGE) {
         unsafe {
-            self.extern_FPDFText_ClosePage().unwrap()(text_page);
+            (self.extern_FPDFText_ClosePage)(text_page);
         }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFText_CountChars(&self, text_page: FPDF_TEXTPAGE) -> c_int {
-        unsafe { self.extern_FPDFText_CountChars().unwrap()(text_page) }
+        unsafe { (self.extern_FPDFText_CountChars)(text_page) }
     }
 
     #[allow(non_snake_case)]
     fn FPDFText_GetUnicode(&self, text_page: FPDF_TEXTPAGE, index: c_int) -> c_uint {
-        unsafe { self.extern_FPDFText_GetUnicode().unwrap()(text_page, index) }
+        unsafe { (self.extern_FPDFText_GetUnicode)(text_page, index) }
     }
 
     #[allow(non_snake_case)]
     fn FPDFText_GetFontSize(&self, text_page: FPDF_TEXTPAGE, index: c_int) -> c_double {
-        unsafe { self.extern_FPDFText_GetFontSize().unwrap()(text_page, index) }
+        unsafe { (self.extern_FPDFText_GetFontSize)(text_page, index) }
     }
 
     #[allow(non_snake_case)]
@@ -6586,14 +3308,12 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buflen: c_ulong,
         flags: *mut c_int,
     ) -> c_ulong {
-        unsafe {
-            self.extern_FPDFText_GetFontInfo().unwrap()(text_page, index, buffer, buflen, flags)
-        }
+        unsafe { (self.extern_FPDFText_GetFontInfo)(text_page, index, buffer, buflen, flags) }
     }
 
     #[allow(non_snake_case)]
     fn FPDFText_GetFontWeight(&self, text_page: FPDF_TEXTPAGE, index: c_int) -> c_int {
-        unsafe { self.extern_FPDFText_GetFontWeight().unwrap()(text_page, index) }
+        unsafe { (self.extern_FPDFText_GetFontWeight)(text_page, index) }
     }
 
     #[allow(non_snake_case)]
@@ -6602,7 +3322,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         text_page: FPDF_TEXTPAGE,
         index: c_int,
     ) -> FPDF_TEXT_RENDERMODE {
-        unsafe { self.extern_FPDFText_GetTextRenderMode().unwrap()(text_page, index) }
+        unsafe { (self.extern_FPDFText_GetTextRenderMode)(text_page, index) }
     }
 
     #[allow(non_snake_case)]
@@ -6615,7 +3335,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         B: *mut c_uint,
         A: *mut c_uint,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFText_GetFillColor().unwrap()(text_page, index, R, G, B, A) }
+        unsafe { (self.extern_FPDFText_GetFillColor)(text_page, index, R, G, B, A) }
     }
 
     #[allow(non_snake_case)]
@@ -6628,12 +3348,12 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         B: *mut c_uint,
         A: *mut c_uint,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFText_GetStrokeColor().unwrap()(text_page, index, R, G, B, A) }
+        unsafe { (self.extern_FPDFText_GetStrokeColor)(text_page, index, R, G, B, A) }
     }
 
     #[allow(non_snake_case)]
     fn FPDFText_GetCharAngle(&self, text_page: FPDF_TEXTPAGE, index: c_int) -> c_float {
-        unsafe { self.extern_FPDFText_GetCharAngle().unwrap()(text_page, index) }
+        unsafe { (self.extern_FPDFText_GetCharAngle)(text_page, index) }
     }
 
     #[allow(non_snake_case)]
@@ -6646,9 +3366,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         bottom: *mut c_double,
         top: *mut c_double,
     ) -> FPDF_BOOL {
-        unsafe {
-            self.extern_FPDFText_GetCharBox().unwrap()(text_page, index, left, right, bottom, top)
-        }
+        unsafe { (self.extern_FPDFText_GetCharBox)(text_page, index, left, right, bottom, top) }
     }
 
     #[allow(non_snake_case)]
@@ -6658,7 +3376,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         index: c_int,
         rect: *mut FS_RECTF,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFText_GetLooseCharBox().unwrap()(text_page, index, rect) }
+        unsafe { (self.extern_FPDFText_GetLooseCharBox)(text_page, index, rect) }
     }
 
     #[allow(non_snake_case)]
@@ -6668,7 +3386,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         index: c_int,
         matrix: *mut FS_MATRIX,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFText_GetMatrix().unwrap()(text_page, index, matrix) }
+        unsafe { (self.extern_FPDFText_GetMatrix)(text_page, index, matrix) }
     }
 
     #[allow(non_snake_case)]
@@ -6679,7 +3397,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         x: *mut c_double,
         y: *mut c_double,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFText_GetCharOrigin().unwrap()(text_page, index, x, y) }
+        unsafe { (self.extern_FPDFText_GetCharOrigin)(text_page, index, x, y) }
     }
 
     #[allow(non_snake_case)]
@@ -6691,11 +3409,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         xTolerance: c_double,
         yTolerance: c_double,
     ) -> c_int {
-        unsafe {
-            self.extern_FPDFText_GetCharIndexAtPos().unwrap()(
-                text_page, x, y, xTolerance, yTolerance,
-            )
-        }
+        unsafe { (self.extern_FPDFText_GetCharIndexAtPos)(text_page, x, y, xTolerance, yTolerance) }
     }
 
     #[allow(non_snake_case)]
@@ -6706,7 +3420,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         count: c_int,
         result: *mut c_ushort,
     ) -> c_int {
-        unsafe { self.extern_FPDFText_GetText().unwrap()(text_page, start_index, count, result) }
+        unsafe { (self.extern_FPDFText_GetText)(text_page, start_index, count, result) }
     }
 
     #[allow(non_snake_case)]
@@ -6716,7 +3430,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         start_index: c_int,
         count: c_int,
     ) -> c_int {
-        unsafe { self.extern_FPDFText_CountRects().unwrap()(text_page, start_index, count) }
+        unsafe { (self.extern_FPDFText_CountRects)(text_page, start_index, count) }
     }
 
     #[allow(non_snake_case)]
@@ -6729,9 +3443,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         right: *mut c_double,
         bottom: *mut c_double,
     ) -> FPDF_BOOL {
-        unsafe {
-            self.extern_FPDFText_GetRect().unwrap()(text_page, rect_index, left, top, right, bottom)
-        }
+        unsafe { (self.extern_FPDFText_GetRect)(text_page, rect_index, left, top, right, bottom) }
     }
 
     #[inline]
@@ -6747,7 +3459,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buflen: c_int,
     ) -> c_int {
         unsafe {
-            self.extern_FPDFText_GetBoundedText().unwrap()(
+            (self.extern_FPDFText_GetBoundedText)(
                 text_page, left, top, right, bottom, buffer, buflen,
             )
         }
@@ -6762,51 +3474,49 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         flags: c_ulong,
         start_index: c_int,
     ) -> FPDF_SCHHANDLE {
-        unsafe {
-            self.extern_FPDFText_FindStart().unwrap()(text_page, findwhat, flags, start_index)
-        }
+        unsafe { (self.extern_FPDFText_FindStart)(text_page, findwhat, flags, start_index) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFText_FindNext(&self, handle: FPDF_SCHHANDLE) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFText_FindNext().unwrap()(handle) }
+        unsafe { (self.extern_FPDFText_FindNext)(handle) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFText_FindPrev(&self, handle: FPDF_SCHHANDLE) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFText_FindPrev().unwrap()(handle) }
+        unsafe { (self.extern_FPDFText_FindPrev)(handle) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFText_GetSchResultIndex(&self, handle: FPDF_SCHHANDLE) -> c_int {
-        unsafe { self.extern_FPDFText_GetSchResultIndex().unwrap()(handle) }
+        unsafe { (self.extern_FPDFText_GetSchResultIndex)(handle) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFText_GetSchCount(&self, handle: FPDF_SCHHANDLE) -> c_int {
-        unsafe { self.extern_FPDFText_GetSchCount().unwrap()(handle) }
+        unsafe { (self.extern_FPDFText_GetSchCount)(handle) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFText_FindClose(&self, handle: FPDF_SCHHANDLE) {
-        unsafe { self.extern_FPDFText_FindClose().unwrap()(handle) }
+        unsafe { (self.extern_FPDFText_FindClose)(handle) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFLink_LoadWebLinks(&self, text_page: FPDF_TEXTPAGE) -> FPDF_PAGELINK {
-        unsafe { self.extern_FPDFLink_LoadWebLinks().unwrap()(text_page) }
+        unsafe { (self.extern_FPDFLink_LoadWebLinks)(text_page) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFLink_CountWebLinks(&self, link_page: FPDF_PAGELINK) -> c_int {
-        unsafe { self.extern_FPDFLink_CountWebLinks().unwrap()(link_page) }
+        unsafe { (self.extern_FPDFLink_CountWebLinks)(link_page) }
     }
 
     #[inline]
@@ -6818,13 +3528,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_ushort,
         buflen: c_int,
     ) -> c_int {
-        unsafe { self.extern_FPDFLink_GetURL().unwrap()(link_page, link_index, buffer, buflen) }
+        unsafe { (self.extern_FPDFLink_GetURL)(link_page, link_index, buffer, buflen) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFLink_CountRects(&self, link_page: FPDF_PAGELINK, link_index: c_int) -> c_int {
-        unsafe { self.extern_FPDFLink_CountRects().unwrap()(link_page, link_index) }
+        unsafe { (self.extern_FPDFLink_CountRects)(link_page, link_index) }
     }
 
     #[inline]
@@ -6841,7 +3551,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         bottom: *mut c_double,
     ) -> FPDF_BOOL {
         unsafe {
-            self.extern_FPDFLink_GetRect().unwrap()(
+            (self.extern_FPDFLink_GetRect)(
                 link_page, link_index, rect_index, left, top, right, bottom,
             )
         }
@@ -6857,19 +3567,14 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         char_count: *mut c_int,
     ) -> FPDF_BOOL {
         unsafe {
-            self.extern_FPDFLink_GetTextRange().unwrap()(
-                link_page,
-                link_index,
-                start_char_index,
-                char_count,
-            )
+            (self.extern_FPDFLink_GetTextRange)(link_page, link_index, start_char_index, char_count)
         }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFLink_CloseWebLinks(&self, link_page: FPDF_PAGELINK) {
-        unsafe { self.extern_FPDFLink_CloseWebLinks().unwrap()(link_page) }
+        unsafe { (self.extern_FPDFLink_CloseWebLinks)(link_page) }
     }
 
     #[inline]
@@ -6880,7 +3585,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_void,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDFPage_GetDecodedThumbnailData().unwrap()(page, buffer, buflen) }
+        unsafe { (self.extern_FPDFPage_GetDecodedThumbnailData)(page, buffer, buflen) }
     }
 
     #[inline]
@@ -6891,19 +3596,19 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_void,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDFPage_GetRawThumbnailData().unwrap()(page, buffer, buflen) }
+        unsafe { (self.extern_FPDFPage_GetRawThumbnailData)(page, buffer, buflen) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPage_GetThumbnailAsBitmap(&self, page: FPDF_PAGE) -> FPDF_BITMAP {
-        unsafe { self.extern_FPDFPage_GetThumbnailAsBitmap().unwrap()(page) }
+        unsafe { (self.extern_FPDFPage_GetThumbnailAsBitmap)(page) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFFormObj_CountObjects(&self, form_object: FPDF_PAGEOBJECT) -> c_int {
-        unsafe { self.extern_FPDFFormObj_CountObjects().unwrap()(form_object) }
+        unsafe { (self.extern_FPDFFormObj_CountObjects)(form_object) }
     }
 
     #[inline]
@@ -6913,7 +3618,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         form_object: FPDF_PAGEOBJECT,
         index: c_ulong,
     ) -> FPDF_PAGEOBJECT {
-        unsafe { self.extern_FPDFFormObj_GetObject().unwrap()(form_object, index) }
+        unsafe { (self.extern_FPDFFormObj_GetObject)(form_object, index) }
     }
 
     #[inline]
@@ -6924,13 +3629,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         font: FPDF_FONT,
         font_size: c_float,
     ) -> FPDF_PAGEOBJECT {
-        unsafe { self.extern_FPDFPageObj_CreateTextObj().unwrap()(document, font, font_size) }
+        unsafe { (self.extern_FPDFPageObj_CreateTextObj)(document, font, font_size) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFTextObj_GetTextRenderMode(&self, text: FPDF_PAGEOBJECT) -> FPDF_TEXT_RENDERMODE {
-        unsafe { self.extern_FPDFTextObj_GetTextRenderMode().unwrap()(text) }
+        unsafe { (self.extern_FPDFTextObj_GetTextRenderMode)(text) }
     }
 
     #[inline]
@@ -6940,7 +3645,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         text: FPDF_PAGEOBJECT,
         render_mode: FPDF_TEXT_RENDERMODE,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFTextObj_SetTextRenderMode().unwrap()(text, render_mode) }
+        unsafe { (self.extern_FPDFTextObj_SetTextRenderMode)(text, render_mode) }
     }
 
     #[inline]
@@ -6952,21 +3657,19 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut FPDF_WCHAR,
         length: c_ulong,
     ) -> c_ulong {
-        unsafe {
-            self.extern_FPDFTextObj_GetText().unwrap()(text_object, text_page, buffer, length)
-        }
+        unsafe { (self.extern_FPDFTextObj_GetText)(text_object, text_page, buffer, length) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFTextObj_GetFont(&self, text: FPDF_PAGEOBJECT) -> FPDF_FONT {
-        unsafe { self.extern_FPDFTextObj_GetFont().unwrap()(text) }
+        unsafe { (self.extern_FPDFTextObj_GetFont)(text) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFTextObj_GetFontSize(&self, text: FPDF_PAGEOBJECT, size: *mut c_float) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFTextObj_GetFontSize().unwrap()(text, size) }
+        unsafe { (self.extern_FPDFTextObj_GetFontSize)(text, size) }
     }
 
     #[inline]
@@ -6979,15 +3682,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     ) -> FPDF_PAGEOBJECT {
         let c_font = CString::new(font).unwrap();
 
-        unsafe {
-            self.extern_FPDFPageObj_NewTextObj().unwrap()(document, c_font.as_ptr(), font_size)
-        }
+        unsafe { (self.extern_FPDFPageObj_NewTextObj)(document, c_font.as_ptr(), font_size) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFText_SetText(&self, text_object: FPDF_PAGEOBJECT, text: FPDF_WIDESTRING) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFText_SetText().unwrap()(text_object, text) }
+        unsafe { (self.extern_FPDFText_SetText)(text_object, text) }
     }
 
     #[inline]
@@ -6998,7 +3699,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         charcodes: *const c_uint,
         count: size_t,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFText_SetCharcodes().unwrap()(text_object, charcodes, count) }
+        unsafe { (self.extern_FPDFText_SetCharcodes)(text_object, charcodes, count) }
     }
 
     #[inline]
@@ -7011,7 +3712,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         font_type: c_int,
         cid: FPDF_BOOL,
     ) -> FPDF_FONT {
-        unsafe { self.extern_FPDFText_LoadFont().unwrap()(document, data, size, font_type, cid) }
+        unsafe { (self.extern_FPDFText_LoadFont)(document, data, size, font_type, cid) }
     }
 
     #[inline]
@@ -7019,25 +3720,25 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     fn FPDFText_LoadStandardFont(&self, document: FPDF_DOCUMENT, font: &str) -> FPDF_FONT {
         let c_font = CString::new(font).unwrap();
 
-        unsafe { self.extern_FPDFText_LoadStandardFont().unwrap()(document, c_font.as_ptr()) }
+        unsafe { (self.extern_FPDFText_LoadStandardFont)(document, c_font.as_ptr()) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFFont_Close(&self, font: FPDF_FONT) {
-        unsafe { self.extern_FPDFFont_Close().unwrap()(font) }
+        unsafe { (self.extern_FPDFFont_Close)(font) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPath_MoveTo(&self, path: FPDF_PAGEOBJECT, x: c_float, y: c_float) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPath_MoveTo().unwrap()(path, x, y) }
+        unsafe { (self.extern_FPDFPath_MoveTo)(path, x, y) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPath_LineTo(&self, path: FPDF_PAGEOBJECT, x: c_float, y: c_float) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPath_LineTo().unwrap()(path, x, y) }
+        unsafe { (self.extern_FPDFPath_LineTo)(path, x, y) }
     }
 
     #[inline]
@@ -7052,13 +3753,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         x3: c_float,
         y3: c_float,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPath_BezierTo().unwrap()(path, x1, y1, x2, y2, x3, y3) }
+        unsafe { (self.extern_FPDFPath_BezierTo)(path, x1, y1, x2, y2, x3, y3) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPath_Close(&self, path: FPDF_PAGEOBJECT) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPath_Close().unwrap()(path) }
+        unsafe { (self.extern_FPDFPath_Close)(path) }
     }
 
     #[inline]
@@ -7069,7 +3770,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         fillmode: c_int,
         stroke: FPDF_BOOL,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPath_SetDrawMode().unwrap()(path, fillmode, stroke) }
+        unsafe { (self.extern_FPDFPath_SetDrawMode)(path, fillmode, stroke) }
     }
 
     #[inline]
@@ -7080,49 +3781,49 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         fillmode: *mut c_int,
         stroke: *mut FPDF_BOOL,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPath_GetDrawMode().unwrap()(path, fillmode, stroke) }
+        unsafe { (self.extern_FPDFPath_GetDrawMode)(path, fillmode, stroke) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPage_InsertObject(&self, page: FPDF_PAGE, page_obj: FPDF_PAGEOBJECT) {
-        unsafe { self.extern_FPDFPage_InsertObject().unwrap()(page, page_obj) }
+        unsafe { (self.extern_FPDFPage_InsertObject)(page, page_obj) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPage_RemoveObject(&self, page: FPDF_PAGE, page_obj: FPDF_PAGEOBJECT) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPage_RemoveObject().unwrap()(page, page_obj) }
+        unsafe { (self.extern_FPDFPage_RemoveObject)(page, page_obj) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPage_CountObjects(&self, page: FPDF_PAGE) -> c_int {
-        unsafe { self.extern_FPDFPage_CountObjects().unwrap()(page) }
+        unsafe { (self.extern_FPDFPage_CountObjects)(page) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPage_GetObject(&self, page: FPDF_PAGE, index: c_int) -> FPDF_PAGEOBJECT {
-        unsafe { self.extern_FPDFPage_GetObject().unwrap()(page, index) }
+        unsafe { (self.extern_FPDFPage_GetObject)(page, index) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPageObj_Destroy(&self, page_obj: FPDF_PAGEOBJECT) {
-        unsafe { self.extern_FPDFPageObj_Destroy().unwrap()(page_obj) }
+        unsafe { (self.extern_FPDFPageObj_Destroy)(page_obj) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPageObj_HasTransparency(&self, page_object: FPDF_PAGEOBJECT) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPageObj_HasTransparency().unwrap()(page_object) }
+        unsafe { (self.extern_FPDFPageObj_HasTransparency)(page_object) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPageObj_GetType(&self, page_object: FPDF_PAGEOBJECT) -> c_int {
-        unsafe { self.extern_FPDFPageObj_GetType().unwrap()(page_object) }
+        unsafe { (self.extern_FPDFPageObj_GetType)(page_object) }
     }
 
     #[inline]
@@ -7137,7 +3838,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         e: c_double,
         f: c_double,
     ) {
-        unsafe { self.extern_FPDFPageObj_Transform().unwrap()(page_object, a, b, c, d, e, f) }
+        unsafe { (self.extern_FPDFPageObj_Transform)(page_object, a, b, c, d, e, f) }
     }
 
     #[inline]
@@ -7147,25 +3848,25 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         page_object: FPDF_PAGEOBJECT,
         matrix: *mut FS_MATRIX,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPageObj_GetMatrix().unwrap()(page_object, matrix) }
+        unsafe { (self.extern_FPDFPageObj_GetMatrix)(page_object, matrix) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPageObj_SetMatrix(&self, path: FPDF_PAGEOBJECT, matrix: *const FS_MATRIX) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPageObj_SetMatrix().unwrap()(path, matrix) }
+        unsafe { (self.extern_FPDFPageObj_SetMatrix)(path, matrix) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPageObj_NewImageObj(&self, document: FPDF_DOCUMENT) -> FPDF_PAGEOBJECT {
-        unsafe { self.extern_FPDFPageObj_NewImageObj().unwrap()(document) }
+        unsafe { (self.extern_FPDFPageObj_NewImageObj)(document) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPageObj_CountMarks(&self, page_object: FPDF_PAGEOBJECT) -> c_int {
-        unsafe { self.extern_FPDFPageObj_CountMarks().unwrap()(page_object) }
+        unsafe { (self.extern_FPDFPageObj_CountMarks)(page_object) }
     }
 
     #[inline]
@@ -7175,7 +3876,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         page_object: FPDF_PAGEOBJECT,
         index: c_ulong,
     ) -> FPDF_PAGEOBJECTMARK {
-        unsafe { self.extern_FPDFPageObj_GetMark().unwrap()(page_object, index) }
+        unsafe { (self.extern_FPDFPageObj_GetMark)(page_object, index) }
     }
 
     #[inline]
@@ -7183,7 +3884,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     fn FPDFPageObj_AddMark(&self, page_object: FPDF_PAGEOBJECT, name: &str) -> FPDF_PAGEOBJECTMARK {
         let c_name = CString::new(name).unwrap();
 
-        unsafe { self.extern_FPDFPageObj_AddMark().unwrap()(page_object, c_name.as_ptr()) }
+        unsafe { (self.extern_FPDFPageObj_AddMark)(page_object, c_name.as_ptr()) }
     }
 
     #[inline]
@@ -7193,7 +3894,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         page_object: FPDF_PAGEOBJECT,
         mark: FPDF_PAGEOBJECTMARK,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPageObj_RemoveMark().unwrap()(page_object, mark) }
+        unsafe { (self.extern_FPDFPageObj_RemoveMark)(page_object, mark) }
     }
 
     #[inline]
@@ -7205,13 +3906,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buflen: c_ulong,
         out_buflen: *mut c_ulong,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPageObjMark_GetName().unwrap()(mark, buffer, buflen, out_buflen) }
+        unsafe { (self.extern_FPDFPageObjMark_GetName)(mark, buffer, buflen, out_buflen) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPageObjMark_CountParams(&self, mark: FPDF_PAGEOBJECTMARK) -> c_int {
-        unsafe { self.extern_FPDFPageObjMark_CountParams().unwrap()(mark) }
+        unsafe { (self.extern_FPDFPageObjMark_CountParams)(mark) }
     }
 
     #[inline]
@@ -7225,9 +3926,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         out_buflen: *mut c_ulong,
     ) -> FPDF_BOOL {
         unsafe {
-            self.extern_FPDFPageObjMark_GetParamKey().unwrap()(
-                mark, index, buffer, buflen, out_buflen,
-            )
+            (self.extern_FPDFPageObjMark_GetParamKey)(mark, index, buffer, buflen, out_buflen)
         }
     }
 
@@ -7240,7 +3939,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     ) -> FPDF_OBJECT_TYPE {
         let c_key = CString::new(key).unwrap();
 
-        unsafe { self.extern_FPDFPageObjMark_GetParamValueType().unwrap()(mark, c_key.as_ptr()) }
+        unsafe { (self.extern_FPDFPageObjMark_GetParamValueType)(mark, c_key.as_ptr()) }
     }
 
     #[inline]
@@ -7253,9 +3952,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     ) -> FPDF_BOOL {
         let c_key = CString::new(key).unwrap();
 
-        unsafe {
-            self.extern_FPDFPageObjMark_GetParamIntValue().unwrap()(mark, c_key.as_ptr(), out_value)
-        }
+        unsafe { (self.extern_FPDFPageObjMark_GetParamIntValue)(mark, c_key.as_ptr(), out_value) }
     }
 
     #[inline]
@@ -7271,7 +3968,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         let c_key = CString::new(key).unwrap();
 
         unsafe {
-            self.extern_FPDFPageObjMark_GetParamStringValue().unwrap()(
+            (self.extern_FPDFPageObjMark_GetParamStringValue)(
                 mark,
                 c_key.as_ptr(),
                 buffer,
@@ -7294,7 +3991,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         let c_key = CString::new(key).unwrap();
 
         unsafe {
-            self.extern_FPDFPageObjMark_GetParamBlobValue().unwrap()(
+            (self.extern_FPDFPageObjMark_GetParamBlobValue)(
                 mark,
                 c_key.as_ptr(),
                 buffer,
@@ -7317,7 +4014,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         let c_key = CString::new(key).unwrap();
 
         unsafe {
-            self.extern_FPDFPageObjMark_SetIntParam().unwrap()(
+            (self.extern_FPDFPageObjMark_SetIntParam)(
                 document,
                 page_object,
                 mark,
@@ -7342,7 +4039,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         let c_value = CString::new(value).unwrap();
 
         unsafe {
-            self.extern_FPDFPageObjMark_SetStringParam().unwrap()(
+            (self.extern_FPDFPageObjMark_SetStringParam)(
                 document,
                 page_object,
                 mark,
@@ -7366,7 +4063,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         let c_key = CString::new(key).unwrap();
 
         unsafe {
-            self.extern_FPDFPageObjMark_SetBlobParam().unwrap()(
+            (self.extern_FPDFPageObjMark_SetBlobParam)(
                 document,
                 page_object,
                 mark,
@@ -7387,9 +4084,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     ) -> FPDF_BOOL {
         let c_key = CString::new(key).unwrap();
 
-        unsafe {
-            self.extern_FPDFPageObjMark_RemoveParam().unwrap()(page_object, mark, c_key.as_ptr())
-        }
+        unsafe { (self.extern_FPDFPageObjMark_RemoveParam)(page_object, mark, c_key.as_ptr()) }
     }
 
     #[inline]
@@ -7401,14 +4096,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         image_object: FPDF_PAGEOBJECT,
         file_access: *mut FPDF_FILEACCESS,
     ) -> FPDF_BOOL {
-        unsafe {
-            self.extern_FPDFImageObj_LoadJpegFile().unwrap()(
-                pages,
-                count,
-                image_object,
-                file_access,
-            )
-        }
+        unsafe { (self.extern_FPDFImageObj_LoadJpegFile)(pages, count, image_object, file_access) }
     }
 
     #[inline]
@@ -7421,12 +4109,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         file_access: *mut FPDF_FILEACCESS,
     ) -> FPDF_BOOL {
         unsafe {
-            self.extern_FPDFImageObj_LoadJpegFileInline().unwrap()(
-                pages,
-                count,
-                image_object,
-                file_access,
-            )
+            (self.extern_FPDFImageObj_LoadJpegFileInline)(pages, count, image_object, file_access)
         }
     }
 
@@ -7442,7 +4125,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         e: c_double,
         f: c_double,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFImageObj_SetMatrix().unwrap()(image_object, a, b, c, d, e, f) }
+        unsafe { (self.extern_FPDFImageObj_SetMatrix)(image_object, a, b, c, d, e, f) }
     }
 
     #[inline]
@@ -7454,13 +4137,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         image_object: FPDF_PAGEOBJECT,
         bitmap: FPDF_BITMAP,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFImageObj_SetBitmap().unwrap()(pages, count, image_object, bitmap) }
+        unsafe { (self.extern_FPDFImageObj_SetBitmap)(pages, count, image_object, bitmap) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFImageObj_GetBitmap(&self, image_object: FPDF_PAGEOBJECT) -> FPDF_BITMAP {
-        unsafe { self.extern_FPDFImageObj_GetBitmap().unwrap()(image_object) }
+        unsafe { (self.extern_FPDFImageObj_GetBitmap)(image_object) }
     }
 
     #[inline]
@@ -7471,9 +4154,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         page: FPDF_PAGE,
         image_object: FPDF_PAGEOBJECT,
     ) -> FPDF_BITMAP {
-        unsafe {
-            self.extern_FPDFImageObj_GetRenderedBitmap().unwrap()(document, page, image_object)
-        }
+        unsafe { (self.extern_FPDFImageObj_GetRenderedBitmap)(document, page, image_object) }
     }
 
     #[inline]
@@ -7484,9 +4165,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_void,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe {
-            self.extern_FPDFImageObj_GetImageDataDecoded().unwrap()(image_object, buffer, buflen)
-        }
+        unsafe { (self.extern_FPDFImageObj_GetImageDataDecoded)(image_object, buffer, buflen) }
     }
 
     #[inline]
@@ -7497,13 +4176,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_void,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDFImageObj_GetImageDataRaw().unwrap()(image_object, buffer, buflen) }
+        unsafe { (self.extern_FPDFImageObj_GetImageDataRaw)(image_object, buffer, buflen) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFImageObj_GetImageFilterCount(&self, image_object: FPDF_PAGEOBJECT) -> c_int {
-        unsafe { self.extern_FPDFImageObj_GetImageFilterCount().unwrap()(image_object) }
+        unsafe { (self.extern_FPDFImageObj_GetImageFilterCount)(image_object) }
     }
 
     #[inline]
@@ -7515,9 +4194,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_void,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe {
-            self.extern_FPDFImageObj_GetImageFilter().unwrap()(image_object, index, buffer, buflen)
-        }
+        unsafe { (self.extern_FPDFImageObj_GetImageFilter)(image_object, index, buffer, buflen) }
     }
 
     #[inline]
@@ -7528,15 +4205,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         page: FPDF_PAGE,
         metadata: *mut FPDF_IMAGEOBJ_METADATA,
     ) -> FPDF_BOOL {
-        unsafe {
-            self.extern_FPDFImageObj_GetImageMetadata().unwrap()(image_object, page, metadata)
-        }
+        unsafe { (self.extern_FPDFImageObj_GetImageMetadata)(image_object, page, metadata) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPageObj_CreateNewPath(&self, x: c_float, y: c_float) -> FPDF_PAGEOBJECT {
-        unsafe { self.extern_FPDFPageObj_CreateNewPath().unwrap()(x, y) }
+        unsafe { (self.extern_FPDFPageObj_CreateNewPath)(x, y) }
     }
 
     #[inline]
@@ -7548,7 +4223,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         w: c_float,
         h: c_float,
     ) -> FPDF_PAGEOBJECT {
-        unsafe { self.extern_FPDFPageObj_CreateNewRect().unwrap()(x, y, w, h) }
+        unsafe { (self.extern_FPDFPageObj_CreateNewRect)(x, y, w, h) }
     }
 
     #[inline]
@@ -7561,9 +4236,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         right: *mut c_float,
         top: *mut c_float,
     ) -> FPDF_BOOL {
-        unsafe {
-            self.extern_FPDFPageObj_GetBounds().unwrap()(page_object, left, bottom, right, top)
-        }
+        unsafe { (self.extern_FPDFPageObj_GetBounds)(page_object, left, bottom, right, top) }
     }
 
     #[inline]
@@ -7571,9 +4244,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     fn FPDFPageObj_SetBlendMode(&self, page_object: FPDF_PAGEOBJECT, blend_mode: &str) {
         let c_blend_mode = CString::new(blend_mode).unwrap();
 
-        unsafe {
-            self.extern_FPDFPageObj_SetBlendMode().unwrap()(page_object, c_blend_mode.as_ptr())
-        }
+        unsafe { (self.extern_FPDFPageObj_SetBlendMode)(page_object, c_blend_mode.as_ptr()) }
     }
 
     #[inline]
@@ -7586,7 +4257,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         B: c_uint,
         A: c_uint,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPageObj_SetStrokeColor().unwrap()(page_object, R, G, B, A) }
+        unsafe { (self.extern_FPDFPageObj_SetStrokeColor)(page_object, R, G, B, A) }
     }
 
     #[inline]
@@ -7599,7 +4270,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         B: *mut c_uint,
         A: *mut c_uint,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPageObj_GetStrokeColor().unwrap()(page_object, R, G, B, A) }
+        unsafe { (self.extern_FPDFPageObj_GetStrokeColor)(page_object, R, G, B, A) }
     }
 
     #[inline]
@@ -7609,7 +4280,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         page_object: FPDF_PAGEOBJECT,
         width: c_float,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPageObj_SetStrokeWidth().unwrap()(page_object, width) }
+        unsafe { (self.extern_FPDFPageObj_SetStrokeWidth)(page_object, width) }
     }
 
     #[inline]
@@ -7619,31 +4290,31 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         page_object: FPDF_PAGEOBJECT,
         width: *mut c_float,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPageObj_GetStrokeWidth().unwrap()(page_object, width) }
+        unsafe { (self.extern_FPDFPageObj_GetStrokeWidth)(page_object, width) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPageObj_GetLineJoin(&self, page_object: FPDF_PAGEOBJECT) -> c_int {
-        unsafe { self.extern_FPDFPageObj_GetLineJoin().unwrap()(page_object) }
+        unsafe { (self.extern_FPDFPageObj_GetLineJoin)(page_object) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPageObj_SetLineJoin(&self, page_object: FPDF_PAGEOBJECT, line_join: c_int) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPageObj_SetLineJoin().unwrap()(page_object, line_join) }
+        unsafe { (self.extern_FPDFPageObj_SetLineJoin)(page_object, line_join) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPageObj_GetLineCap(&self, page_object: FPDF_PAGEOBJECT) -> c_int {
-        unsafe { self.extern_FPDFPageObj_GetLineCap().unwrap()(page_object) }
+        unsafe { (self.extern_FPDFPageObj_GetLineCap)(page_object) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPageObj_SetLineCap(&self, page_object: FPDF_PAGEOBJECT, line_cap: c_int) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPageObj_SetLineCap().unwrap()(page_object, line_cap) }
+        unsafe { (self.extern_FPDFPageObj_SetLineCap)(page_object, line_cap) }
     }
 
     #[inline]
@@ -7656,7 +4327,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         B: c_uint,
         A: c_uint,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPageObj_SetFillColor().unwrap()(page_object, R, G, B, A) }
+        unsafe { (self.extern_FPDFPageObj_SetFillColor)(page_object, R, G, B, A) }
     }
 
     #[inline]
@@ -7669,7 +4340,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         B: *mut c_uint,
         A: *mut c_uint,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPageObj_GetFillColor().unwrap()(page_object, R, G, B, A) }
+        unsafe { (self.extern_FPDFPageObj_GetFillColor)(page_object, R, G, B, A) }
     }
 
     #[inline]
@@ -7679,19 +4350,19 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         page_object: FPDF_PAGEOBJECT,
         phase: *mut c_float,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPageObj_GetDashPhase().unwrap()(page_object, phase) }
+        unsafe { (self.extern_FPDFPageObj_GetDashPhase)(page_object, phase) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPageObj_SetDashPhase(&self, page_object: FPDF_PAGEOBJECT, phase: c_float) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPageObj_SetDashPhase().unwrap()(page_object, phase) }
+        unsafe { (self.extern_FPDFPageObj_SetDashPhase)(page_object, phase) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPageObj_GetDashCount(&self, page_object: FPDF_PAGEOBJECT) -> c_int {
-        unsafe { self.extern_FPDFPageObj_GetDashCount().unwrap()(page_object) }
+        unsafe { (self.extern_FPDFPageObj_GetDashCount)(page_object) }
     }
 
     #[inline]
@@ -7702,9 +4373,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         dash_array: *mut c_float,
         dash_count: size_t,
     ) -> FPDF_BOOL {
-        unsafe {
-            self.extern_FPDFPageObj_GetDashArray().unwrap()(page_object, dash_array, dash_count)
-        }
+        unsafe { (self.extern_FPDFPageObj_GetDashArray)(page_object, dash_array, dash_count) }
     }
 
     #[inline]
@@ -7717,25 +4386,20 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         phase: c_float,
     ) -> FPDF_BOOL {
         unsafe {
-            self.extern_FPDFPageObj_SetDashArray().unwrap()(
-                page_object,
-                dash_array,
-                dash_count,
-                phase,
-            )
+            (self.extern_FPDFPageObj_SetDashArray)(page_object, dash_array, dash_count, phase)
         }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPath_CountSegments(&self, path: FPDF_PAGEOBJECT) -> c_int {
-        unsafe { self.extern_FPDFPath_CountSegments().unwrap()(path) }
+        unsafe { (self.extern_FPDFPath_CountSegments)(path) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPath_GetPathSegment(&self, path: FPDF_PAGEOBJECT, index: c_int) -> FPDF_PATHSEGMENT {
-        unsafe { self.extern_FPDFPath_GetPathSegment().unwrap()(path, index) }
+        unsafe { (self.extern_FPDFPath_GetPathSegment)(path, index) }
     }
 
     #[inline]
@@ -7746,19 +4410,19 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         x: *mut c_float,
         y: *mut c_float,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPathSegment_GetPoint().unwrap()(segment, x, y) }
+        unsafe { (self.extern_FPDFPathSegment_GetPoint)(segment, x, y) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPathSegment_GetType(&self, segment: FPDF_PATHSEGMENT) -> c_int {
-        unsafe { self.extern_FPDFPathSegment_GetType().unwrap()(segment) }
+        unsafe { (self.extern_FPDFPathSegment_GetType)(segment) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFPathSegment_GetClose(&self, segment: FPDF_PATHSEGMENT) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFPathSegment_GetClose().unwrap()(segment) }
+        unsafe { (self.extern_FPDFPathSegment_GetClose)(segment) }
     }
 
     #[inline]
@@ -7769,25 +4433,25 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut c_char,
         length: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDFFont_GetFontName().unwrap()(font, buffer, length) }
+        unsafe { (self.extern_FPDFFont_GetFontName)(font, buffer, length) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFFont_GetFlags(&self, font: FPDF_FONT) -> c_int {
-        unsafe { self.extern_FPDFFont_GetFlags().unwrap()(font) }
+        unsafe { (self.extern_FPDFFont_GetFlags)(font) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFFont_GetWeight(&self, font: FPDF_FONT) -> c_int {
-        unsafe { self.extern_FPDFFont_GetWeight().unwrap()(font) }
+        unsafe { (self.extern_FPDFFont_GetWeight)(font) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFFont_GetItalicAngle(&self, font: FPDF_FONT, angle: *mut c_int) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFFont_GetItalicAngle().unwrap()(font, angle) }
+        unsafe { (self.extern_FPDFFont_GetItalicAngle)(font, angle) }
     }
 
     #[inline]
@@ -7798,7 +4462,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         font_size: c_float,
         ascent: *mut c_float,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFFont_GetAscent().unwrap()(font, font_size, ascent) }
+        unsafe { (self.extern_FPDFFont_GetAscent)(font, font_size, ascent) }
     }
 
     #[inline]
@@ -7809,7 +4473,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         font_size: c_float,
         descent: *mut c_float,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFFont_GetDescent().unwrap()(font, font_size, descent) }
+        unsafe { (self.extern_FPDFFont_GetDescent)(font, font_size, descent) }
     }
 
     #[inline]
@@ -7821,7 +4485,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         font_size: c_float,
         width: *mut c_float,
     ) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFFont_GetGlyphWidth().unwrap()(font, glyph, font_size, width) }
+        unsafe { (self.extern_FPDFFont_GetGlyphWidth)(font, glyph, font_size, width) }
     }
 
     #[inline]
@@ -7832,13 +4496,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         glyph: c_uint,
         font_size: c_float,
     ) -> FPDF_GLYPHPATH {
-        unsafe { self.extern_FPDFFont_GetGlyphPath().unwrap()(font, glyph, font_size) }
+        unsafe { (self.extern_FPDFFont_GetGlyphPath)(font, glyph, font_size) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFGlyphPath_CountGlyphSegments(&self, glyphpath: FPDF_GLYPHPATH) -> c_int {
-        unsafe { self.extern_FPDFGlyphPath_CountGlyphSegments().unwrap()(glyphpath) }
+        unsafe { (self.extern_FPDFGlyphPath_CountGlyphSegments)(glyphpath) }
     }
 
     #[inline]
@@ -7848,31 +4512,31 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         glyphpath: FPDF_GLYPHPATH,
         index: c_int,
     ) -> FPDF_PATHSEGMENT {
-        unsafe { self.extern_FPDFGlyphPath_GetGlyphPathSegment().unwrap()(glyphpath, index) }
+        unsafe { (self.extern_FPDFGlyphPath_GetGlyphPathSegment)(glyphpath, index) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_VIEWERREF_GetPrintScaling(&self, document: FPDF_DOCUMENT) -> FPDF_BOOL {
-        unsafe { self.extern_FPDF_VIEWERREF_GetPrintScaling().unwrap()(document) }
+        unsafe { (self.extern_FPDF_VIEWERREF_GetPrintScaling)(document) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_VIEWERREF_GetNumCopies(&self, document: FPDF_DOCUMENT) -> c_int {
-        unsafe { self.extern_FPDF_VIEWERREF_GetNumCopies().unwrap()(document) }
+        unsafe { (self.extern_FPDF_VIEWERREF_GetNumCopies)(document) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_VIEWERREF_GetPrintPageRange(&self, document: FPDF_DOCUMENT) -> FPDF_PAGERANGE {
-        unsafe { self.extern_FPDF_VIEWERREF_GetPrintPageRange().unwrap()(document) }
+        unsafe { (self.extern_FPDF_VIEWERREF_GetPrintPageRange)(document) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_VIEWERREF_GetPrintPageRangeCount(&self, pagerange: FPDF_PAGERANGE) -> size_t {
-        unsafe { self.extern_FPDF_VIEWERREF_GetPrintPageRangeCount().unwrap()(pagerange) }
+        unsafe { (self.extern_FPDF_VIEWERREF_GetPrintPageRangeCount)(pagerange) }
     }
 
     #[inline]
@@ -7882,16 +4546,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         pagerange: FPDF_PAGERANGE,
         index: size_t,
     ) -> c_int {
-        unsafe {
-            self.extern_FPDF_VIEWERREF_GetPrintPageRangeElement()
-                .unwrap()(pagerange, index)
-        }
+        unsafe { (self.extern_FPDF_VIEWERREF_GetPrintPageRangeElement)(pagerange, index) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDF_VIEWERREF_GetDuplex(&self, document: FPDF_DOCUMENT) -> FPDF_DUPLEXTYPE {
-        unsafe { self.extern_FPDF_VIEWERREF_GetDuplex().unwrap()(document) }
+        unsafe { (self.extern_FPDF_VIEWERREF_GetDuplex)(document) }
     }
 
     #[inline]
@@ -7905,15 +4566,13 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     ) -> c_ulong {
         let c_key = CString::new(key).unwrap();
 
-        unsafe {
-            self.extern_FPDF_VIEWERREF_GetName().unwrap()(document, c_key.as_ptr(), buffer, length)
-        }
+        unsafe { (self.extern_FPDF_VIEWERREF_GetName)(document, c_key.as_ptr(), buffer, length) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFDoc_GetAttachmentCount(&self, document: FPDF_DOCUMENT) -> c_int {
-        unsafe { self.extern_FPDFDoc_GetAttachmentCount().unwrap()(document) }
+        unsafe { (self.extern_FPDFDoc_GetAttachmentCount)(document) }
     }
 
     #[inline]
@@ -7923,19 +4582,19 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         document: FPDF_DOCUMENT,
         name: FPDF_WIDESTRING,
     ) -> FPDF_ATTACHMENT {
-        unsafe { self.extern_FPDFDoc_AddAttachment().unwrap()(document, name) }
+        unsafe { (self.extern_FPDFDoc_AddAttachment)(document, name) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFDoc_GetAttachment(&self, document: FPDF_DOCUMENT, index: c_int) -> FPDF_ATTACHMENT {
-        unsafe { self.extern_FPDFDoc_GetAttachment().unwrap()(document, index) }
+        unsafe { (self.extern_FPDFDoc_GetAttachment)(document, index) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFDoc_DeleteAttachment(&self, document: FPDF_DOCUMENT, index: c_int) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFDoc_DeleteAttachment().unwrap()(document, index) }
+        unsafe { (self.extern_FPDFDoc_DeleteAttachment)(document, index) }
     }
 
     #[inline]
@@ -7946,7 +4605,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buffer: *mut FPDF_WCHAR,
         buflen: c_ulong,
     ) -> c_ulong {
-        unsafe { self.extern_FPDFAttachment_GetName().unwrap()(attachment, buffer, buflen) }
+        unsafe { (self.extern_FPDFAttachment_GetName)(attachment, buffer, buflen) }
     }
 
     #[inline]
@@ -7954,7 +4613,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     fn FPDFAttachment_HasKey(&self, attachment: FPDF_ATTACHMENT, key: &str) -> FPDF_BOOL {
         let c_key = CString::new(key).unwrap();
 
-        unsafe { self.extern_FPDFAttachment_HasKey().unwrap()(attachment, c_key.as_ptr()) }
+        unsafe { (self.extern_FPDFAttachment_HasKey)(attachment, c_key.as_ptr()) }
     }
 
     #[inline]
@@ -7966,7 +4625,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     ) -> FPDF_OBJECT_TYPE {
         let c_key = CString::new(key).unwrap();
 
-        unsafe { self.extern_FPDFAttachment_GetValueType().unwrap()(attachment, c_key.as_ptr()) }
+        unsafe { (self.extern_FPDFAttachment_GetValueType)(attachment, c_key.as_ptr()) }
     }
 
     #[inline]
@@ -7979,9 +4638,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     ) -> FPDF_BOOL {
         let c_key = CString::new(key).unwrap();
 
-        unsafe {
-            self.extern_FPDFAttachment_SetStringValue().unwrap()(attachment, c_key.as_ptr(), value)
-        }
+        unsafe { (self.extern_FPDFAttachment_SetStringValue)(attachment, c_key.as_ptr(), value) }
     }
 
     #[inline]
@@ -7996,12 +4653,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         let c_key = CString::new(key).unwrap();
 
         unsafe {
-            self.extern_FPDFAttachment_GetStringValue().unwrap()(
-                attachment,
-                c_key.as_ptr(),
-                buffer,
-                buflen,
-            )
+            (self.extern_FPDFAttachment_GetStringValue)(attachment, c_key.as_ptr(), buffer, buflen)
         }
     }
 
@@ -8014,9 +4666,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         contents: *const c_void,
         len: c_ulong,
     ) -> FPDF_BOOL {
-        unsafe {
-            self.extern_FPDFAttachment_SetFile().unwrap()(attachment, document, contents, len)
-        }
+        unsafe { (self.extern_FPDFAttachment_SetFile)(attachment, document, contents, len) }
     }
 
     #[inline]
@@ -8028,14 +4678,12 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         buflen: c_ulong,
         out_buflen: *mut c_ulong,
     ) -> FPDF_BOOL {
-        unsafe {
-            self.extern_FPDFAttachment_GetFile().unwrap()(attachment, buffer, buflen, out_buflen)
-        }
+        unsafe { (self.extern_FPDFAttachment_GetFile)(attachment, buffer, buflen, out_buflen) }
     }
 
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFCatalog_IsTagged(&self, document: FPDF_DOCUMENT) -> FPDF_BOOL {
-        unsafe { self.extern_FPDFCatalog_IsTagged().unwrap()(document) }
+        unsafe { (self.extern_FPDFCatalog_IsTagged)(document) }
     }
 }

--- a/src/native.rs
+++ b/src/native.rs
@@ -7,7 +7,7 @@ use crate::bindgen::{
     FPDF_PAGE, FPDF_PAGELINK, FPDF_PAGEOBJECT, FPDF_PAGEOBJECTMARK, FPDF_PAGERANGE,
     FPDF_PATHSEGMENT, FPDF_SCHHANDLE, FPDF_SIGNATURE, FPDF_STRING, FPDF_STRUCTELEMENT,
     FPDF_STRUCTTREE, FPDF_TEXTPAGE, FPDF_TEXT_RENDERMODE, FPDF_WCHAR, FPDF_WIDESTRING, FS_FLOAT,
-    FS_MATRIX, FS_POINTF, FS_QUADPOINTSF, FS_RECTF,
+    FS_MATRIX, FS_POINTF, FS_QUADPOINTSF, FS_RECTF, FS_SIZEF,
 };
 use crate::bindings::PdfiumLibraryBindings;
 use libloading::{Library, Symbol};
@@ -50,6 +50,7 @@ impl DynamicPdfiumBindings {
         result.extern_FPDF_ImportNPagesToOne()?;
         result.extern_FPDF_GetPageLabel()?;
         result.extern_FPDF_GetPageBoundingBox()?;
+        result.extern_FPDF_GetPageSizeByIndexF()?;
         result.extern_FPDF_GetPageWidthF()?;
         result.extern_FPDF_GetPageHeightF()?;
         result.extern_FPDFText_GetCharIndexFromTextIndex()?;
@@ -696,6 +697,17 @@ impl DynamicPdfiumBindings {
         libloading::Error,
     > {
         unsafe { self.library.get(b"FPDF_GetPageBoundingBox\0") }
+    }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    fn extern_FPDF_GetPageSizeByIndexF(
+        &self,
+    ) -> Result<
+        Symbol<unsafe extern "C" fn(page: FPDF_DOCUMENT, page_index: c_int, size: *mut FS_SIZEF) -> FPDF_BOOL>,
+        libloading::Error,
+    > {
+        unsafe { self.library.get(b"FPDF_GetPageSizeByIndexF\0") }
     }
 
     #[inline]
@@ -5361,6 +5373,12 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     #[allow(non_snake_case)]
     fn FPDF_GetPageBoundingBox(&self, page: FPDF_PAGE, rect: *mut FS_RECTF) -> FPDF_BOOL {
         unsafe { self.extern_FPDF_GetPageBoundingBox().unwrap()(page, rect) }
+    }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    fn FPDF_GetPageSizeByIndexF(&self, document: FPDF_DOCUMENT, page_index: c_int, size: *mut FS_SIZEF) -> FPDF_BOOL {
+        unsafe { self.extern_FPDF_GetPageSizeByIndexF().unwrap()(document, page_index, size) }
     }
 
     #[inline]

--- a/src/pages.rs
+++ b/src/pages.rs
@@ -2,7 +2,9 @@
 //! `PdfDocument`.
 
 use crate::bindgen::{
-    size_t, FPDF_DOCUMENT, FPDF_FORMHANDLE, FPDF_PAGE, FS_SIZEF, PAGEMODE_FULLSCREEN, PAGEMODE_UNKNOWN, PAGEMODE_USEATTACHMENTS, PAGEMODE_USENONE, PAGEMODE_USEOC, PAGEMODE_USEOUTLINES, PAGEMODE_USETHUMBS
+    size_t, FPDF_DOCUMENT, FPDF_FORMHANDLE, FPDF_PAGE, FS_SIZEF, PAGEMODE_FULLSCREEN,
+    PAGEMODE_UNKNOWN, PAGEMODE_USEATTACHMENTS, PAGEMODE_USENONE, PAGEMODE_USEOC,
+    PAGEMODE_USEOUTLINES, PAGEMODE_USETHUMBS,
 };
 use crate::bindings::PdfiumLibraryBindings;
 use crate::document::PdfDocument;
@@ -146,11 +148,20 @@ impl<'a> PdfPages<'a> {
             width: 0.,
             height: 0.,
         };
-        let result = self
+        if self
             .bindings
-            .FPDF_GetPageSizeByIndexF(self.document_handle, index.into(), &mut size);
-
-        Ok(size)
+            .is_true(self.bindings.FPDF_GetPageSizeByIndexF(
+                self.document_handle,
+                index.into(),
+                &mut size,
+            ))
+        {
+            Ok(size)
+        } else {
+            Err(PdfiumError::PdfiumLibraryInternalError(
+                PdfiumInternalError::Unknown,
+            ))
+        }
     }
 
     /// Returns the first [PdfPage] in this [PdfPages] collection.

--- a/src/pages.rs
+++ b/src/pages.rs
@@ -2,9 +2,7 @@
 //! `PdfDocument`.
 
 use crate::bindgen::{
-    size_t, FPDF_DOCUMENT, FPDF_FORMHANDLE, FPDF_PAGE, PAGEMODE_FULLSCREEN, PAGEMODE_UNKNOWN,
-    PAGEMODE_USEATTACHMENTS, PAGEMODE_USENONE, PAGEMODE_USEOC, PAGEMODE_USEOUTLINES,
-    PAGEMODE_USETHUMBS,
+    size_t, FPDF_DOCUMENT, FPDF_FORMHANDLE, FPDF_PAGE, FS_SIZEF, PAGEMODE_FULLSCREEN, PAGEMODE_UNKNOWN, PAGEMODE_USEATTACHMENTS, PAGEMODE_USENONE, PAGEMODE_USEOC, PAGEMODE_USEOUTLINES, PAGEMODE_USETHUMBS
 };
 use crate::bindings::PdfiumLibraryBindings;
 use crate::document::PdfDocument;
@@ -141,6 +139,18 @@ impl<'a> PdfPages<'a> {
         }
 
         result
+    }
+
+    pub fn get_size(&self, index: PdfPageIndex) -> Result<FS_SIZEF, PdfiumError> {
+        let mut size = FS_SIZEF {
+            width: 0.,
+            height: 0.,
+        };
+        let result = self
+            .bindings
+            .FPDF_GetPageSizeByIndexF(self.document_handle, index.into(), &mut size);
+
+        Ok(size)
     }
 
     /// Returns the first [PdfPage] in this [PdfPages] collection.

--- a/src/thread_safe.rs
+++ b/src/thread_safe.rs
@@ -13,7 +13,7 @@ use crate::bindgen::{
     FPDF_IMAGEOBJ_METADATA, FPDF_LINK, FPDF_OBJECT_TYPE, FPDF_PAGE, FPDF_PAGELINK, FPDF_PAGEOBJECT,
     FPDF_PAGEOBJECTMARK, FPDF_PAGERANGE, FPDF_PATHSEGMENT, FPDF_SCHHANDLE, FPDF_SIGNATURE,
     FPDF_STRUCTELEMENT, FPDF_STRUCTTREE, FPDF_TEXTPAGE, FPDF_TEXT_RENDERMODE, FPDF_WCHAR,
-    FPDF_WIDESTRING, FS_FLOAT, FS_MATRIX, FS_POINTF, FS_QUADPOINTSF, FS_RECTF,
+    FPDF_WIDESTRING, FS_FLOAT, FS_MATRIX, FS_POINTF, FS_QUADPOINTSF, FS_RECTF, FS_SIZEF,
 };
 use crate::bindings::PdfiumLibraryBindings;
 use once_cell::sync::Lazy;
@@ -571,6 +571,12 @@ impl<T: PdfiumLibraryBindings> PdfiumLibraryBindings for ThreadSafePdfiumBinding
     #[allow(non_snake_case)]
     fn FPDF_GetPageBoundingBox(&self, page: FPDF_PAGE, rect: *mut FS_RECTF) -> FPDF_BOOL {
         self.bindings.FPDF_GetPageBoundingBox(page, rect)
+    }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    fn FPDF_GetPageSizeByIndexF(&self, document: FPDF_DOCUMENT, page_index: c_int, size: *mut FS_SIZEF) -> FPDF_BOOL {
+        self.bindings.FPDF_GetPageSizeByIndexF(document, page_index, size)
     }
 
     #[inline]


### PR DESCRIPTION
First, sorry for combining effectively two PRs into one, but exposing FPDF_GetPageSizeByIndexF also requires changing the bindings.

FPDF_GetPageSizeByIndexF is much faster than loading each page and then obtaining its dimensions. For a large book with hundreds of pages, FPDF_GetPageSizeByIndexF only takes a fraction of a second vs several seconds.

I also noticed that the DynamicPdfiumBindings reload the symbol from libloading for every call. It is much more efficient to store the function pointers in the struct. This should bring the overhead in line with "normal" dynamic linking. Taking the function pointers out of the symbol is "unsafe" but it is fine as long as their lifetime does not exceed that of the Library (see https://users.rust-lang.org/t/multiple-objects-with-interdependent-lifetimes-in-the-same-struct/16507/3).
I created the symbol table with the following script: https://gist.github.com/DorianRudolph/1be46b909764faa5559673936342bc3f

Lastly, you can also use the StaticPdfiumBindings with dynamic linking, for which I added the PDFIUM_DYNAMIC_LIB_PATH environment variable to the build.rs. This does not require any changes besides linker flags.