### PR TITLE
Bumping image crate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bitflags = "2"
 bytes = "1"
 bytemuck = "1"
 chrono = "0"
-image = { version = ">= 0.24.0", optional = true } # DynamicImage trait definitions changed between 0.23.14 and 0.24.0; we use trait from version 0.24.0 and later.
+image = { version = ">= 0.25.1", optional = true } # DynamicImage trait definitions changed between 0.23.14 and 0.24.0; we use trait from version 0.24.0 and later.
 iter_tools = "0"
 log = "0"
 maybe-owned = "0"


### PR DESCRIPTION
We use your lib on [Spacedrive](https://github.com/spacedriveapp/spacedrive) and we're trying to update our image crate version to get better performance on jpeg decoding mostly, but we're having conflicting image crate versions. I've run your tests here and everything seems to keep working with this version bump.