### PR TITLE
fix tests: use rgb8 instead of rgba8 for saving JPEG

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,8 +209,7 @@ mod tests {
             for (index, page) in document.pages().iter().enumerate() {
                 page.render_with_config(&render_config)?
                     .as_image() // Renders this page to an Image::DynamicImage...
-                    .as_rgba8() // ... then converts it to an Image::Image ...
-                    .ok_or(PdfiumError::ImageError)?
+                    .into_rgb8() // ... then converts it to an Image::Image ...
                     .save_with_format(format!("test-page-{}.jpg", index), image::ImageFormat::Jpeg) // ... and saves it to a file.
                     .map_err(|_| PdfiumError::ImageError)?;
             }
@@ -242,8 +241,7 @@ mod tests {
             let result = page
                 .render_with_config(&render_config)?
                 .as_image()
-                .as_rgba8()
-                .ok_or(PdfiumError::ImageError)?
+                .into_rgb8()
                 .save_with_format(format!("form-test-page-{}.jpg", index), ImageFormat::Jpeg);
 
             assert!(result.is_ok());

--- a/src/page.rs
+++ b/src/page.rs
@@ -1095,8 +1095,7 @@ mod tests {
 
             bitmap
                 .as_image()
-                .as_rgba8()
-                .ok_or(PdfiumError::ImageError)?
+                .into_rgb8()
                 .save_with_format(format!("test-page-{}.jpg", index), image::ImageFormat::Jpeg)
                 .map_err(|_| PdfiumError::ImageError)?;
         }


### PR DESCRIPTION
The `save_with_format` call failed with `Unsupported(UnsupportedError { format: Exact(Jpeg), kind: Color(Rgba8) })`, since JPEG does not have an alpha channel.