### PR TITLE
Bindings for FPDFPage_TransformAnnots()

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -654,7 +654,7 @@ pub trait PdfiumLibraryBindings {
         d: f64,
         e: f64,
         f: f64,
-    ) -> FPDF_BOOL;
+    );
 
     #[allow(non_snake_case)]
     fn FPDFBitmap_CreateEx(

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -645,6 +645,18 @@ pub trait PdfiumLibraryBindings {
     fn FPDFPage_GenerateContent(&self, page: FPDF_PAGE) -> FPDF_BOOL;
 
     #[allow(non_snake_case)]
+    fn FPDFPage_TransformAnnots(
+        &self,
+        page: FPDF_PAGE,
+        a: f64,
+        b: f64,
+        c: f64,
+        d: f64,
+        e: f64,
+        f: f64,
+    ) -> FPDF_BOOL;
+
+    #[allow(non_snake_case)]
     fn FPDFBitmap_CreateEx(
         &self,
         width: c_int,

--- a/src/native.rs
+++ b/src/native.rs
@@ -1402,6 +1402,27 @@ impl DynamicPdfiumBindings {
 
     #[inline]
     #[allow(non_snake_case)]
+    fn extern_FPDFPage_TransformAnnots(
+        &self,
+    ) -> Result<
+        Symbol<
+            unsafe extern "C" fn(
+                page: FPDF_PAGE,
+                a: c_double,
+                b: c_double,
+                c: c_double,
+                d: c_double,
+                e: c_double,
+                f: c_double,
+            ) -> FPDF_BOOL,
+        >,
+        libloading::Error,
+    > {
+        unsafe { self.library.get(b"FPDFPage_TransformAnnots\0") }
+    }
+
+    #[inline]
+    #[allow(non_snake_case)]
     fn extern_FPDFBitmap_CreateEx(
         &self,
     ) -> Result<

--- a/src/native.rs
+++ b/src/native.rs
@@ -100,6 +100,7 @@ impl DynamicPdfiumBindings {
         result.extern_FPDFPage_InsertClipPath()?;
         result.extern_FPDFPage_HasTransparency()?;
         result.extern_FPDFPage_GenerateContent()?;
+        result.extern_FPDFPage_TransformAnnots()?;
         result.extern_FPDFBitmap_CreateEx()?;
         result.extern_FPDFBitmap_Destroy()?;
         result.extern_FPDFBitmap_GetFormat()?;
@@ -5601,6 +5602,21 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
     #[allow(non_snake_case)]
     fn FPDFPage_GenerateContent(&self, page: FPDF_PAGE) -> FPDF_BOOL {
         unsafe { self.extern_FPDFPage_GenerateContent().unwrap()(page) }
+    }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    fn FPDFPage_TransformAnnots(
+        &self,
+        page: FPDF_PAGE,
+        a: f64,
+        b: f64,
+        c: f64,
+        d: f64,
+        e: f64,
+        f: f64,
+    ) -> FPDF_BOOL {
+        unsafe { self.extern_FPDFPage_TransformAnnots().unwrap()(page, a, b, c, d, e, f) }
     }
 
     #[inline]

--- a/src/native.rs
+++ b/src/native.rs
@@ -1415,7 +1415,7 @@ impl DynamicPdfiumBindings {
                 d: c_double,
                 e: c_double,
                 f: c_double,
-            ) -> FPDF_BOOL,
+            ),
         >,
         libloading::Error,
     > {
@@ -5615,7 +5615,7 @@ impl PdfiumLibraryBindings for DynamicPdfiumBindings {
         d: f64,
         e: f64,
         f: f64,
-    ) -> FPDF_BOOL {
+    ) {
         unsafe { self.extern_FPDFPage_TransformAnnots().unwrap()(page, a, b, c, d, e, f) }
     }
 

--- a/src/thread_safe.rs
+++ b/src/thread_safe.rs
@@ -812,7 +812,7 @@ impl<T: PdfiumLibraryBindings> PdfiumLibraryBindings for ThreadSafePdfiumBinding
         d: f64,
         e: f64,
         f: f64,
-    ) -> FPDF_BOOL {
+    ) {
         self.bindings
             .FPDFPage_TransformAnnots(page, a, b, c, d, e, f)
     }

--- a/src/thread_safe.rs
+++ b/src/thread_safe.rs
@@ -802,6 +802,21 @@ impl<T: PdfiumLibraryBindings> PdfiumLibraryBindings for ThreadSafePdfiumBinding
         self.bindings.FPDFPage_GenerateContent(page)
     }
 
+    #[allow(non_snake_case)]
+    fn FPDFPage_TransformAnnots(
+        &self,
+        page: FPDF_PAGE,
+        a: f64,
+        b: f64,
+        c: f64,
+        d: f64,
+        e: f64,
+        f: f64,
+    ) -> FPDF_BOOL {
+        self.bindings
+            .FPDFPage_TransformAnnots(page, a, b, c, d, e, f)
+    }
+
     #[inline]
     #[allow(non_snake_case)]
     fn FPDFBitmap_CreateEx(

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -3684,34 +3684,31 @@ impl PdfiumLibraryBindings for WasmPdfiumBindings {
         d: c_double,
         e: c_double,
         f: c_double,
-    ) -> FPDF_BOOL {
+    ) {
         log::debug!("pdfium-render::PdfiumLibraryBindings::FPDFPage_TransformAnnots()");
 
-        PdfiumRenderWasmState::lock()
-            .call(
-                "FPDFPage_TransformAnnots",
+        PdfiumRenderWasmState::lock().call(
+            "FPDFPage_TransformAnnots",
+            JsFunctionArgumentType::Number,
+            Some(vec![
+                JsFunctionArgumentType::Pointer,
                 JsFunctionArgumentType::Number,
-                Some(vec![
-                    JsFunctionArgumentType::Pointer,
-                    JsFunctionArgumentType::Number,
-                    JsFunctionArgumentType::Number,
-                    JsFunctionArgumentType::Number,
-                    JsFunctionArgumentType::Number,
-                    JsFunctionArgumentType::Number,
-                    JsFunctionArgumentType::Number,
-                ]),
-                Some(&JsValue::from(Array::of7(
-                    &Self::js_value_from_page(page),
-                    &JsValue::from(a),
-                    &JsValue::from(b),
-                    &JsValue::from(c),
-                    &JsValue::from(d),
-                    &JsValue::from(e),
-                    &JsValue::from(f),
-                ))),
-            )
-            .as_f64()
-            .unwrap() as FPDF_BOOL
+                JsFunctionArgumentType::Number,
+                JsFunctionArgumentType::Number,
+                JsFunctionArgumentType::Number,
+                JsFunctionArgumentType::Number,
+                JsFunctionArgumentType::Number,
+            ]),
+            Some(&JsValue::from(Array::of7(
+                &Self::js_value_from_page(page),
+                &JsValue::from(a),
+                &JsValue::from(b),
+                &JsValue::from(c),
+                &JsValue::from(d),
+                &JsValue::from(e),
+                &JsValue::from(f),
+            ))),
+        )
     }
 
     #[allow(non_snake_case)]

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -3675,6 +3675,46 @@ impl PdfiumLibraryBindings for WasmPdfiumBindings {
     }
 
     #[allow(non_snake_case)]
+    fn FPDFPage_TransformAnnots(
+        &self,
+        page: FPDF_PAGE,
+        a: c_double,
+        b: c_double,
+        c: c_double,
+        d: c_double,
+        e: c_double,
+        f: c_double,
+    ) -> FPDF_BOOL {
+        log::debug!("pdfium-render::PdfiumLibraryBindings::FPDFPage_TransformAnnots()");
+
+        PdfiumRenderWasmState::lock()
+            .call(
+                "FPDFPage_TransformAnnots",
+                JsFunctionArgumentType::Number,
+                Some(vec![
+                    JsFunctionArgumentType::Pointer,
+                    JsFunctionArgumentType::Number,
+                    JsFunctionArgumentType::Number,
+                    JsFunctionArgumentType::Number,
+                    JsFunctionArgumentType::Number,
+                    JsFunctionArgumentType::Number,
+                    JsFunctionArgumentType::Number,
+                ]),
+                Some(&JsValue::from(Array::of7(
+                    &Self::js_value_from_page(page),
+                    &JsValue::from(a),
+                    &JsValue::from(b),
+                    &JsValue::from(c),
+                    &JsValue::from(d),
+                    &JsValue::from(e),
+                    &JsValue::from(f),
+                ))),
+            )
+            .as_f64()
+            .unwrap() as FPDF_BOOL
+    }
+
+    #[allow(non_snake_case)]
     fn FPDFBitmap_CreateEx(
         &self,
         width: c_int,


### PR DESCRIPTION
Not much to say here, just adding bindings.

For context: I am experimenting with calling `FPDFPage_TransformAnnots()` from `regenerate_content_immut_for_handle()`, as form annotations aren't displaying under some circumstances. But that's another PR for another time.