### PR TITLE
Fix unsound bitmap buffers vec instead of a dropped vec's pointer

### DIFF
--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -2962,7 +2962,7 @@ pub trait PdfiumLibraryBindings {
     /// Use [PdfiumLibraryBindings::FPDFBitmap_GetFormat] to find out the format of the data.
     #[allow(non_snake_case)]
     #[cfg(target_arch = "wasm32")]
-    fn FPDFBitmap_GetBuffer(&self, bitmap: FPDF_BITMAP) -> *const c_void;
+    fn FPDFBitmap_GetBuffer(&self, bitmap: FPDF_BITMAP) -> Vec<u8>;
 
     /// This function is not part of the Pdfium API. It is provided by `pdfium-render` as an
     /// alternative to directly mutating the data returned by

--- a/src/bindings/thread_safe.rs
+++ b/src/bindings/thread_safe.rs
@@ -1640,7 +1640,7 @@ impl<T: PdfiumLibraryBindings> PdfiumLibraryBindings for ThreadSafePdfiumBinding
     #[inline]
     #[allow(non_snake_case)]
     #[cfg(target_arch = "wasm32")]
-    fn FPDFBitmap_GetBuffer(&self, bitmap: FPDF_BITMAP) -> *const c_void {
+    fn FPDFBitmap_GetBuffer(&self, bitmap: FPDF_BITMAP) -> Vec<u8> {
         self.bindings.FPDFBitmap_GetBuffer(bitmap)
     }
 

--- a/src/bindings/wasm.rs
+++ b/src/bindings/wasm.rs
@@ -676,9 +676,12 @@ impl PdfiumRenderWasmState {
             .heap_u8()
             .slice(ptr as u32, (ptr + len) as u32)
             .to_vec();
+        
 
         if self.debug {
             let mut differences_count = 0;
+ 
+            log::debug!("pdfium-render::PdfiumRenderWasmState::copy_bytes_from_pdfium(): copied to new buffer at offset {}", copy.as_ptr() as usize);
 
             let pdfium_heap = self.heap_u8();
 
@@ -699,6 +702,11 @@ impl PdfiumRenderWasmState {
 
             log::debug!("pdfium-render::PdfiumRenderWasmState::copy_bytes_from_pdfium(): {} bytes differ between source and destination byte buffers", differences_count);
         }
+
+        let copy2: Vec<u8> = Vec::with_capacity(len);
+
+        log::debug!("pdfium-render::PdfiumRenderWasmState::copy_bytes_from_pdfium(): setup copy at {}, original is {}", copy2.as_ptr() as usize, copy.as_ptr() as usize);
+
 
         log::debug!("pdfium-render::PdfiumRenderWasmState::copy_bytes_from_pdfium(): leaving");
 
@@ -6214,7 +6222,7 @@ impl PdfiumLibraryBindings for WasmPdfiumBindings {
     }
 
     #[allow(non_snake_case)]
-    fn FPDFBitmap_GetBuffer(&self, bitmap: FPDF_BITMAP) -> *const c_void {
+    fn FPDFBitmap_GetBuffer(&self, bitmap: FPDF_BITMAP) -> Vec<u8> {
         log::debug!("pdfium-render::PdfiumLibraryBindings::FPDFBitmap_GetBuffer()");
 
         let width = self.FPDFBitmap_GetWidth(bitmap);
@@ -6237,9 +6245,7 @@ impl PdfiumLibraryBindings for WasmPdfiumBindings {
             .as_f64()
             .unwrap() as usize;
 
-        let buffer = state.copy_bytes_from_pdfium(buffer_ptr, buffer_len);
-
-        buffer.as_ptr() as *const c_void
+        state.copy_bytes_from_pdfium(buffer_ptr, buffer_len)
     }
 
     #[allow(non_snake_case)]


### PR DESCRIPTION
Here's my initial attempt at resolving the unsound bitmap buffer method (issue #174), quick and dirty. I'm using it locally in a fork, but this submission is just to give ideas about how you'd like this tackled.

The nice part is that there are method we can use to write code that works equally well on a &[u8] (from the native code path) and a Vec<u8> (from the wasm code path):
* `.as_ref()` on a `&[u8]` and a `Vec<u8>` return the same thing: `&[u8]`
* `Vec::from(buffer)` works on both a `&[u8]` and `Vec<u8>`

