### PR TITLE
Add PdfLink::rect()

### DIFF
--- a/src/pdf/link.rs
+++ b/src/pdf/link.rs
@@ -1,10 +1,11 @@
 //! Defines the [PdfLink] struct, exposing functionality related to a single link contained
 //! within a [PdfPage], a [PdfPageAnnotation], or a [PdfBookmark].
 
-use crate::bindgen::{FPDF_DOCUMENT, FPDF_LINK};
+use crate::bindgen::{FPDF_DOCUMENT, FPDF_LINK, FS_RECTF};
 use crate::bindings::PdfiumLibraryBindings;
 use crate::pdf::action::PdfAction;
 use crate::pdf::destination::PdfDestination;
+use crate::pdf::rect::PdfRect;
 
 #[cfg(doc)]
 use {
@@ -87,5 +88,63 @@ impl<'a> PdfLink<'a> {
                 self.bindings(),
             ))
         }
+    }
+
+    /// Returns the [PdfRect] associated with this [PdfLink], if any.
+    ///
+    /// The PdfRect specifies the area on the page that can be clicked on to activate the link.
+    pub fn rect(&self) -> Option<PdfRect> {
+        // If the underlying Pdfium function is named FPDFLink_GetAnnotRect(), then why is this
+        // function named rect() and not annot_rect() or somesuch?  Because the name of
+        // FPDFLink_GetAnnotRect() comes from Pdfium's public API calling links "Link Annotations".
+        // For clarity, pdfium-render doesn't follow that convention; in fact, Pdfium doesn't even
+        // follow it internally - it's internal function that does the same thing is named
+        // CPDF_Link::GetRect().
+        let mut the_rect = FS_RECTF {
+            left: 0.,
+            top: 0.,
+            right: 0.,
+            bottom: 0.,
+        };
+        let result = self
+            .bindings()
+            .FPDFLink_GetAnnotRect(self.handle(), &mut the_rect);
+        match result {
+            0 => None,
+            _ => Some(PdfRect::from_pdfium(the_rect)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+    use crate::utils::test::test_bind_to_pdfium;
+
+    #[test]
+    fn test_link_rect() -> Result<(), PdfiumError> {
+        let pdfium = test_bind_to_pdfium();
+        let document = pdfium.load_pdf_from_file("./test/links-test.pdf", None)?;
+        // The document contains a single page with a single link
+        const EXPECTED: PdfRect = PdfRect::new_from_values(733.3627, 207.85417, 757.6127, 333.1458);
+        // Allow a little bit of error, because it's unreasonable to expect floating point
+        // calculations to be identical across builds and platforms.
+        const ABS_ERR: PdfPoints = PdfPoints::new(f32::EPSILON * 1000.);
+        let actual = document
+            .pages()
+            .iter()
+            .next()
+            .unwrap()
+            .links()
+            .iter()
+            .next()
+            .unwrap()
+            .rect()
+            .unwrap();
+        assert!((actual.top() - EXPECTED.top()).abs() < ABS_ERR);
+        assert!((actual.bottom() - EXPECTED.bottom()).abs() < ABS_ERR);
+        assert!((actual.left() - EXPECTED.left()).abs() < ABS_ERR);
+        assert!((actual.right() - EXPECTED.right()).abs() < ABS_ERR);
+        Ok(())
     }
 }


### PR DESCRIPTION
Adds `PdfLink::rect()` as a binding to `FPDFLink_GetAnnotRect()`, along with a basic test for it.