### PR TITLE
Update wasm binding dependencies and solve problems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ windows = { version = "0", optional = true }
 [build-dependencies]
 # Bindgen 0.70.0 and later cause build failures when compiling to WASM. For more details, see:
 # https://github.com/ajrcarey/pdfium-render/issues/156
-bindgen = { version = "<=0.69.4", optional = true }
+bindgen = { version = "0.71.1", optional = true }
 
 [dev-dependencies]
 # Dependencies specific to examples. Dependencies for the WASM example in examples/wasm.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,9 +55,7 @@ libloading = "0"
 windows = { version = "0", optional = true }
 
 [build-dependencies]
-# Bindgen 0.70.0 and later cause build failures when compiling to WASM. For more details, see:
-# https://github.com/ajrcarey/pdfium-render/issues/156
-bindgen = { version = "0.71.1", optional = true }
+bindgen = { version = "0.71", optional = true }
 
 [dev-dependencies]
 # Dependencies specific to examples. Dependencies for the WASM example in examples/wasm.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,7 @@ vecmath = "1"
 console_log = "1"
 console_error_panic_hook = "0"
 js-sys = "0"
-# wasm-bindgen 0.2.96 causes a build failure when compiling as part of github actions.
-# For more details, see: https://github.com/ajrcarey/pdfium-render/issues/177
-wasm-bindgen = { version = "<= 0.2.95", features = ["enable-interning"] }
+wasm-bindgen = { version = ">=0.2.97", features = ["enable-interning"] }
 wasm-bindgen-futures = { version = "0" }
 web-sys = { version = "0", features = [
     "TextDecoder",


### PR DESCRIPTION
Too many problems have been caused by using "<=" for bindgen dependencies
There are many other libraries that use wasm bindgen and other libraries that use pdfium-render. Having to deal with dependency conflicts because of this has been annoying.