### PR TITLE
Account for stride being different that row byte length in grayscale images too.

### DIFF
--- a/src/pdf/document/page/object/image.rs
+++ b/src/pdf/document/page/object/image.rs
@@ -27,21 +27,21 @@ use {crate::utils::files::get_pdfium_file_accessor_from_reader, std::fs::File, s
 #[cfg(any(feature = "image_latest", feature = "image_025"))]
 use {
     crate::pdf::bitmap::PdfBitmapFormat,
-    crate::utils::pixels::{aligned_bgr_to_rgba, bgra_to_rgba, rgba_to_bgra},
+    crate::utils::pixels::{aligned_bgr_to_rgba, aligned_grayscale, bgra_to_rgba, rgba_to_bgra},
     image_025::{DynamicImage, EncodableLayout, GrayImage, RgbaImage},
 };
 
 #[cfg(feature = "image_024")]
 use {
     crate::pdf::bitmap::PdfBitmapFormat,
-    crate::utils::pixels::{aligned_bgr_to_rgba, bgra_to_rgba, rgba_to_bgra},
+    crate::utils::pixels::{aligned_bgr_to_rgba, aligned_grayscale, bgra_to_rgba, rgba_to_bgra},
     image_024::{DynamicImage, EncodableLayout, GrayImage, RgbaImage},
 };
 
 #[cfg(feature = "image_023")]
 use {
     crate::pdf::bitmap::PdfBitmapFormat,
-    crate::utils::pixels::{aligned_bgr_to_rgba, bgra_to_rgba, rgba_to_bgra},
+    crate::utils::pixels::{aligned_bgr_to_rgba, aligned_grayscale, bgra_to_rgba, rgba_to_bgra},
     image_023::{DynamicImage, EncodableLayout, GenericImageView, GrayImage, RgbaImage},
 };
 
@@ -585,10 +585,11 @@ impl<'a> PdfPageImageObject<'a> {
                 aligned_bgr_to_rgba(buffer, width as usize, stride as usize),
             )
             .map(DynamicImage::ImageRgba8),
-            PdfBitmapFormat::Gray => {
-                GrayImage::from_raw(width as u32, height as u32, buffer.to_vec())
-                    .map(DynamicImage::ImageLuma8)
-            }
+            PdfBitmapFormat::Gray => GrayImage::from_raw(
+                width as u32, 
+                height as u32, 
+                aligned_grayscale(buffer, width as usize, stride as usize)
+            ).map(DynamicImage::ImageLuma8),
         }
         .ok_or(PdfiumError::ImageError)
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 pub(crate) mod pixels {
 
+    const BYTES_PER_GRAYSCALE_PIXEL: usize = 1;
     const BYTES_PER_THREE_CHANNEL_PIXEL: usize = 3;
 
     const BYTES_PER_FOUR_CHANNEL_PIXEL: usize = 4;
@@ -130,6 +131,16 @@ pub(crate) mod pixels {
         // Expanding from three-channel to four-channel pixel data by adding an alpha channel
         // is the same irrespective of the pixel color format.
         aligned_rgb_to_rgba(bgr, width, stride)
+    }
+
+    #[inline]
+    pub(crate) fn aligned_grayscale(grayscale: &[u8], width: usize, stride: usize) -> Vec<u8> {
+        grayscale.chunks_exact(stride)
+            .flat_map(|scanline| {
+                &scanline[..width * BYTES_PER_GRAYSCALE_PIXEL]
+            })
+            .copied()
+            .collect::<Vec<u8>>()
     }
 }
 


### PR DESCRIPTION
PR #118 fixed stride issues for color images, but I've run into issues with grayscale issues. This PR adds the same type of logic for the grayscale images.

I've attached a PDF with an embedded image that's 499x499 pixels, which demonstrates the issue. I've attached screenshots of what good vs bad decoding looks like (note that my screenshots capture a stretched image due to some other stuff I'm working on locally, but it shows the general issue).

![Screenshot 2025-04-01 at 9 42 56 AM](https://github.com/user-attachments/assets/76a4eccc-b435-41b2-95c9-1f159a1397e9)
![Screenshot 2025-04-01 at 9 40 58 AM](https://github.com/user-attachments/assets/17a33b75-f489-44f0-b0dc-e4dbde14da13)

[grayscale_embedded_image.pdf](https://github.com/user-attachments/files/19552955/grayscale_embedded_image.pdf)
