### PR TITLE
Optimize PdfPageObjectsPrivate.get_impl

### DIFF
--- a/src/pdf/document/page/objects.rs
+++ b/src/pdf/document/page/objects.rs
@@ -145,15 +145,14 @@ impl<'a> PdfPageObjectsPrivate<'a> for PdfPageObjects<'a> {
     }
 
     fn get_impl(&self, index: PdfPageObjectIndex) -> Result<PdfPageObject<'a>, PdfiumError> {
-        if index >= self.len() {
-            return Err(PdfiumError::PageObjectIndexOutOfBounds);
-        }
-
         let object_handle = self
             .bindings
             .FPDFPage_GetObject(self.page_handle, index as c_int);
 
         if object_handle.is_null() {
+            if index >= self.len() {
+                return Err(PdfiumError::PageObjectIndexOutOfBounds);
+            }
             Err(PdfiumError::PdfiumLibraryInternalError(
                 PdfiumInternalError::Unknown,
             ))


### PR DESCRIPTION
While iterating a PDF with large object count I noticed that each `.get` was calling `FPDFPage_CountObjects`, this PR avoids that extra FFI call on each `get_impl` making iteration quite slow. To avoid introducing a breaking change I lazy load the error in case of `nullptr`

```rs
objects.iter().collect()
```

**before**
```
objects: 2294
iter: 14.46ms
```
**after**
```
objects: 2294
iter: 9.438ms
```
