### PR TITLE
Remove unused image features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ bitflags = "2"
 bytes = "1"
 bytemuck = "1"
 chrono = "0"
-image_025 = { package = "image", version = "0.25", optional = true }
-image_024 = { package = "image", version = "0.24", optional = true }
-image_023 = { package = "image", version = "0.23", optional = true }
+image_025 = { package = "image", version = "0.25", optional = true, default-features = false }
+image_024 = { package = "image", version = "0.24", optional = true, default-features = false }
+image_023 = { package = "image", version = "0.23", optional = true, default-features = false }
 itertools = "0"
 log = "0"
 maybe-owned = "0"


### PR DESCRIPTION
This helped to decrease number of lines inside `Cargo.lock` from 2265 to 1507

This library do not need to decode jpgs/pngs or qoi file formats