### PR TITLE
Chore: fixed clippy warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ examples/serve
 examples/Cargo.lock
 examples/test*.jpg
 examples/test*.png
+form-test-page-*.jpg
 
 # Do not check IntelliJ-specific files into source control
 

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -18,6 +18,8 @@
 // the PdfiumLibraryBindings trait depending on whether we are compiling to a WASM module,
 // a native shared library, or a statically linked library.
 
+#![allow(clippy::too_many_arguments)]
+
 #[cfg(not(target_arch = "wasm32"))]
 #[cfg(not(feature = "static"))]
 pub(crate) mod dynamic;
@@ -9358,7 +9360,7 @@ pub trait PdfiumLibraryBindings {
     /// Call this function twice to get the name of the named destination:
     /// * First time pass in `buffer` as `NULL` and get `buflen`.
     /// * Second time pass in allocated `buffer` and `buflen` to retrieve `buffer`,
-    /// which should be used as `wchar_t*`.
+    ///   which should be used as `wchar_t*`.
     ///
     /// If `buflen` is not sufficiently large, it will be set to -1 upon return.
     #[allow(non_snake_case)]

--- a/src/bindings/dynamic.rs
+++ b/src/bindings/dynamic.rs
@@ -2329,9 +2329,7 @@ impl DynamicPdfiumBindings {
     fn bind<'a, T>(library: &'a Library, function: &str) -> Result<Symbol<'a, T>, PdfiumError> {
         let c_function = CString::new(function).map_err(|err| {
             PdfiumError::LoadLibraryFunctionNameError(format!(
-                "Error converting function name to CString: {}, message: {}",
-                function,
-                err.to_string()
+                "Error converting function name to CString: {function}, message: {err}"
             ))
         })?;
 

--- a/src/bindings/thread_safe.rs
+++ b/src/bindings/thread_safe.rs
@@ -67,8 +67,7 @@ impl PdfiumThreadMarshall {
             Ok(lock) => lock,
             Err(err) => {
                 log::error!(
-                    "PdfiumThreadMarshall::lock(): unable to acquire thread lock: {:#?}",
-                    err
+                    "PdfiumThreadMarshall::lock(): unable to acquire thread lock: {err:#?}"
                 );
                 log::error!("This may indicate a programming error in pdfium-render. Please file an issue: https://github.com/ajrcarey/pdfium-render/issues");
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -228,7 +228,7 @@ pub enum PdfiumError {
 
 impl Display for PdfiumError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{:#?}", self)
+        write!(f, "{self:#?}")
     }
 }
 

--- a/src/pdf/document/bookmark.rs
+++ b/src/pdf/document/bookmark.rs
@@ -181,7 +181,7 @@ impl<'a> PdfBookmark<'a> {
         // the child tree should be displayed closed by deafult.
         self.bindings
             .FPDFBookmark_GetCount(self.bookmark_handle)
-            .abs() as usize
+            .unsigned_abs() as usize
     }
 
     /// Returns the first child [PdfBookmark] of this [PdfBookmark], if any.

--- a/src/pdf/document/page/annotation/circle.rs
+++ b/src/pdf/document/page/annotation/circle.rs
@@ -52,7 +52,7 @@ impl<'a> PdfPageAnnotationPrivate<'a> for PdfPageCircleAnnotation<'a> {
 
     #[inline]
     fn ownership(&self) -> &PdfPageObjectOwnership {
-        &self.objects_impl().ownership()
+        self.objects_impl().ownership()
     }
 
     #[inline]

--- a/src/pdf/document/page/annotation/free_text.rs
+++ b/src/pdf/document/page/annotation/free_text.rs
@@ -52,7 +52,7 @@ impl<'a> PdfPageAnnotationPrivate<'a> for PdfPageFreeTextAnnotation<'a> {
 
     #[inline]
     fn ownership(&self) -> &PdfPageObjectOwnership {
-        &self.objects_impl().ownership()
+        self.objects_impl().ownership()
     }
 
     #[inline]

--- a/src/pdf/document/page/annotation/highlight.rs
+++ b/src/pdf/document/page/annotation/highlight.rs
@@ -58,7 +58,7 @@ impl<'a> PdfPageAnnotationPrivate<'a> for PdfPageHighlightAnnotation<'a> {
 
     #[inline]
     fn ownership(&self) -> &PdfPageObjectOwnership {
-        &self.objects_impl().ownership()
+        self.objects_impl().ownership()
     }
 
     #[inline]

--- a/src/pdf/document/page/annotation/ink.rs
+++ b/src/pdf/document/page/annotation/ink.rs
@@ -58,7 +58,7 @@ impl<'a> PdfPageAnnotationPrivate<'a> for PdfPageInkAnnotation<'a> {
 
     #[inline]
     fn ownership(&self) -> &PdfPageObjectOwnership {
-        &self.objects_impl().ownership()
+        self.objects_impl().ownership()
     }
 
     #[inline]

--- a/src/pdf/document/page/annotation/link.rs
+++ b/src/pdf/document/page/annotation/link.rs
@@ -106,7 +106,7 @@ impl<'a> PdfPageAnnotationPrivate<'a> for PdfPageLinkAnnotation<'a> {
 
     #[inline]
     fn ownership(&self) -> &PdfPageObjectOwnership {
-        &self.objects_impl().ownership()
+        self.objects_impl().ownership()
     }
 
     #[inline]

--- a/src/pdf/document/page/annotation/objects.rs
+++ b/src/pdf/document/page/annotation/objects.rs
@@ -93,7 +93,7 @@ impl<'a> PdfPageObjectsPrivate<'a> for PdfPageAnnotationObjects<'a> {
         } else {
             Ok(PdfPageObject::from_pdfium(
                 object_handle,
-                self.ownership().clone(),
+                *self.ownership(),
                 self.bindings,
             ))
         }

--- a/src/pdf/document/page/annotation/popup.rs
+++ b/src/pdf/document/page/annotation/popup.rs
@@ -52,7 +52,7 @@ impl<'a> PdfPageAnnotationPrivate<'a> for PdfPagePopupAnnotation<'a> {
 
     #[inline]
     fn ownership(&self) -> &PdfPageObjectOwnership {
-        &self.objects_impl().ownership()
+        self.objects_impl().ownership()
     }
 
     #[inline]

--- a/src/pdf/document/page/annotation/redacted.rs
+++ b/src/pdf/document/page/annotation/redacted.rs
@@ -52,7 +52,7 @@ impl<'a> PdfPageAnnotationPrivate<'a> for PdfPageRedactedAnnotation<'a> {
 
     #[inline]
     fn ownership(&self) -> &PdfPageObjectOwnership {
-        &self.objects_impl().ownership()
+        self.objects_impl().ownership()
     }
 
     #[inline]

--- a/src/pdf/document/page/annotation/square.rs
+++ b/src/pdf/document/page/annotation/square.rs
@@ -52,7 +52,7 @@ impl<'a> PdfPageAnnotationPrivate<'a> for PdfPageSquareAnnotation<'a> {
 
     #[inline]
     fn ownership(&self) -> &PdfPageObjectOwnership {
-        &self.objects_impl().ownership()
+        self.objects_impl().ownership()
     }
 
     #[inline]

--- a/src/pdf/document/page/annotation/squiggly.rs
+++ b/src/pdf/document/page/annotation/squiggly.rs
@@ -58,7 +58,7 @@ impl<'a> PdfPageAnnotationPrivate<'a> for PdfPageSquigglyAnnotation<'a> {
 
     #[inline]
     fn ownership(&self) -> &PdfPageObjectOwnership {
-        &self.objects_impl().ownership()
+        self.objects_impl().ownership()
     }
 
     #[inline]

--- a/src/pdf/document/page/annotation/stamp.rs
+++ b/src/pdf/document/page/annotation/stamp.rs
@@ -58,7 +58,7 @@ impl<'a> PdfPageAnnotationPrivate<'a> for PdfPageStampAnnotation<'a> {
 
     #[inline]
     fn ownership(&self) -> &PdfPageObjectOwnership {
-        &self.objects_impl().ownership()
+        self.objects_impl().ownership()
     }
 
     #[inline]

--- a/src/pdf/document/page/annotation/strikeout.rs
+++ b/src/pdf/document/page/annotation/strikeout.rs
@@ -58,7 +58,7 @@ impl<'a> PdfPageAnnotationPrivate<'a> for PdfPageStrikeoutAnnotation<'a> {
 
     #[inline]
     fn ownership(&self) -> &PdfPageObjectOwnership {
-        &self.objects_impl().ownership()
+        self.objects_impl().ownership()
     }
 
     #[inline]

--- a/src/pdf/document/page/annotation/text.rs
+++ b/src/pdf/document/page/annotation/text.rs
@@ -52,7 +52,7 @@ impl<'a> PdfPageAnnotationPrivate<'a> for PdfPageTextAnnotation<'a> {
 
     #[inline]
     fn ownership(&self) -> &PdfPageObjectOwnership {
-        &self.objects_impl().ownership()
+        self.objects_impl().ownership()
     }
 
     #[inline]

--- a/src/pdf/document/page/annotation/underline.rs
+++ b/src/pdf/document/page/annotation/underline.rs
@@ -58,7 +58,7 @@ impl<'a> PdfPageAnnotationPrivate<'a> for PdfPageUnderlineAnnotation<'a> {
 
     #[inline]
     fn ownership(&self) -> &PdfPageObjectOwnership {
-        &self.objects_impl().ownership()
+        self.objects_impl().ownership()
     }
 
     #[inline]

--- a/src/pdf/document/page/annotation/unsupported.rs
+++ b/src/pdf/document/page/annotation/unsupported.rs
@@ -63,7 +63,7 @@ impl<'a> PdfPageAnnotationPrivate<'a> for PdfPageUnsupportedAnnotation<'a> {
 
     #[inline]
     fn ownership(&self) -> &PdfPageObjectOwnership {
-        &self.objects_impl().ownership()
+        self.objects_impl().ownership()
     }
 
     #[inline]

--- a/src/pdf/document/page/annotation/widget.rs
+++ b/src/pdf/document/page/annotation/widget.rs
@@ -75,7 +75,7 @@ impl<'a> PdfPageAnnotationPrivate<'a> for PdfPageWidgetAnnotation<'a> {
 
     #[inline]
     fn ownership(&self) -> &PdfPageObjectOwnership {
-        &self.objects_impl().ownership()
+        self.objects_impl().ownership()
     }
 
     #[inline]

--- a/src/pdf/document/page/annotation/xfa_widget.rs
+++ b/src/pdf/document/page/annotation/xfa_widget.rs
@@ -75,7 +75,7 @@ impl<'a> PdfPageAnnotationPrivate<'a> for PdfPageXfaWidgetAnnotation<'a> {
 
     #[inline]
     fn ownership(&self) -> &PdfPageObjectOwnership {
-        &self.objects_impl().ownership()
+        self.objects_impl().ownership()
     }
 
     #[inline]

--- a/src/pdf/document/page/object/group.rs
+++ b/src/pdf/document/page/object/group.rs
@@ -293,7 +293,7 @@ impl<'a> PdfPageGroupObject<'a> {
             let mut object = PdfPageObject::from_pdfium(
                 self.bindings()
                     .FPDFPage_GetObject(self.page_handle(), index),
-                self.ownership().clone(),
+                *self.ownership(),
                 self.bindings(),
             );
 
@@ -712,7 +712,7 @@ impl<'a> PdfPageGroupObject<'a> {
         for index in 0..self.bindings.FPDFPage_CountObjects(self.page_handle) {
             let object = PdfPageObject::from_pdfium(
                 self.bindings().FPDFPage_GetObject(self.page_handle, index),
-                self.ownership().clone(),
+                *self.ownership(),
                 self.bindings(),
             );
 
@@ -783,7 +783,7 @@ impl<'a> PdfPageGroupObject<'a> {
     #[inline]
     pub fn has_transparency(&self) -> bool {
         self.object_handles.iter().any(|object_handle| {
-            PdfPageObject::from_pdfium(*object_handle, self.ownership().clone(), self.bindings())
+            PdfPageObject::from_pdfium(*object_handle, *self.ownership(), self.bindings())
                 .has_transparency()
         })
     }
@@ -798,12 +798,9 @@ impl<'a> PdfPageGroupObject<'a> {
         let mut empty = true;
 
         self.object_handles.iter().for_each(|object_handle| {
-            if let Ok(object_bounds) = PdfPageObject::from_pdfium(
-                *object_handle,
-                self.ownership().clone(),
-                self.bindings(),
-            )
-            .bounds()
+            if let Ok(object_bounds) =
+                PdfPageObject::from_pdfium(*object_handle, *self.ownership(), self.bindings())
+                    .bounds()
             {
                 empty = false;
 
@@ -939,7 +936,7 @@ impl<'a> PdfPageGroupObject<'a> {
     /// Inflates an internal `FPDF_PAGEOBJECT` handle into a [PdfPageObject].
     #[inline]
     pub(crate) fn get_object_from_handle(&self, handle: &FPDF_PAGEOBJECT) -> PdfPageObject<'a> {
-        PdfPageObject::from_pdfium(*handle, self.ownership().clone(), self.bindings())
+        PdfPageObject::from_pdfium(*handle, *self.ownership(), self.bindings())
     }
 
     create_transform_setters!(

--- a/src/pdf/document/page/object/ownership.rs
+++ b/src/pdf/document/page/object/ownership.rs
@@ -133,9 +133,6 @@ impl PdfPageObjectOwnership {
     /// this [PdfObjectOwnership] instance is owned by an object container attached to
     /// either a [PdfPage] or a [PdfAnnotation].
     pub fn is_owned(&self) -> bool {
-        match self {
-            PdfPageObjectOwnership::Unowned => false,
-            _ => true,
-        }
+        !matches!(self, PdfPageObjectOwnership::Unowned)
     }
 }

--- a/src/pdf/document/page/object/private.rs
+++ b/src/pdf/document/page/object/private.rs
@@ -471,7 +471,7 @@ pub(crate) mod internal {
         ) -> Result<PdfPageObject<'b>, PdfiumError> {
             let mut object = PdfPageObject::from_pdfium(
                 self.object_handle(),
-                self.ownership().clone(),
+                *self.ownership(),
                 page.bindings(),
             );
 

--- a/src/pdf/document/page/object/x_object_form.rs
+++ b/src/pdf/document/page/object/x_object_form.rs
@@ -202,7 +202,7 @@ impl<'a> PdfPageObjectsPrivate<'a> for PdfPageXObjectFormObject<'a> {
         } else {
             Ok(PdfPageObject::from_pdfium(
                 object_handle,
-                PdfPageObjectPrivate::ownership(self).clone(),
+                *PdfPageObjectPrivate::ownership(self),
                 PdfPageObjectsPrivate::bindings(self),
             ))
         }

--- a/src/pdf/document/page/objects.rs
+++ b/src/pdf/document/page/objects.rs
@@ -178,7 +178,7 @@ impl<'a> PdfPageObjectsPrivate<'a> for PdfPageObjects<'a> {
         } else {
             Ok(PdfPageObject::from_pdfium(
                 object_handle,
-                self.ownership().clone(),
+                *self.ownership(),
                 self.bindings(),
             ))
         }

--- a/src/pdf/document/page/text/char.rs
+++ b/src/pdf/document/page/text/char.rs
@@ -129,7 +129,7 @@ impl<'a> PdfPageTextChar<'a> {
     /// [PdfPageTextChar::unscaled_font_size] function.
     #[inline]
     pub fn scaled_font_size(&self) -> PdfPoints {
-        PdfPoints::new(self.unscaled_font_size().value * (self.get_vertical_scale() as f32))
+        PdfPoints::new(self.unscaled_font_size().value * self.get_vertical_scale())
     }
 
     /// Returns the font size applied to this character.

--- a/src/pdf/document/page/text/chars.rs
+++ b/src/pdf/document/page/text/chars.rs
@@ -105,7 +105,7 @@ impl<'a> PdfPageTextChars<'a> {
                 self.document_handle(),
                 self.page_handle(),
                 self.text_page_handle(),
-                *index as i32,
+                *index,
                 self.bindings(),
             )),
             None => Err(PdfiumError::CharIndexOutOfBounds),

--- a/src/pdf/document/page/text/search.rs
+++ b/src/pdf/document/page/text/search.rs
@@ -133,10 +133,10 @@ impl<'a> PdfPageTextSearch<'a> {
                 .FPDFText_GetSchResultIndex(self.search_handle());
             let count = self.bindings().FPDFText_GetSchCount(self.search_handle());
 
-            return Some(self.text_page.segments_subset(
+            Some(self.text_page.segments_subset(
                 start_index as PdfPageTextCharIndex,
                 count as PdfPageTextCharIndex,
-            ));
+            ))
         } else {
             None
         }

--- a/src/pdf/font.rs
+++ b/src/pdf/font.rs
@@ -1179,7 +1179,7 @@ impl<'a> PdfFont<'a> {
 
             let buffer_length = out_buflen;
 
-            let mut buffer = create_byte_buffer(buffer_length as usize);
+            let mut buffer = create_byte_buffer(buffer_length);
 
             let result = self.bindings().FPDFFont_GetFontData(
                 self.handle,

--- a/src/pdf/path/clip_path.rs
+++ b/src/pdf/path/clip_path.rs
@@ -1,4 +1,5 @@
 //! Defines the [PdfClipPath] struct, exposing functionality related to a clip path.
+#![allow(dead_code)]
 #[doc(hidden)]
 use crate::bindgen::FPDF_CLIPPATH;
 use crate::bindings::PdfiumLibraryBindings;
@@ -13,7 +14,6 @@ use std::os::raw::c_int;
 // that implements the PdfPathSegments trait. Want to complete implementation of top-level PdfClipPath
 // collection, then add clip path support to pages and page objects.
 
-#[allow(dead_code)]
 // The PdfClipPath struct is not currently used, but we expect it to be in future
 pub struct PdfClipPath<'a> {
     // TODO: AJRC - 22/10/22 - this will contain a collection of paths

--- a/src/pdf/quad_points.rs
+++ b/src/pdf/quad_points.rs
@@ -133,10 +133,10 @@ impl PdfQuadPoints {
             y3,
             x4,
             y4,
-            left: *vec![x1, x2, x3, x4].iter().min().unwrap(),
-            right: *vec![x1, x2, x3, x4].iter().max().unwrap(),
-            bottom: *vec![y1, y2, y3, y4].iter().min().unwrap(),
-            top: *vec![y1, y2, y3, y4].iter().max().unwrap(),
+            left: *[x1, x2, x3, x4].iter().min().unwrap(),
+            right: *[x1, x2, x3, x4].iter().max().unwrap(),
+            bottom: *[y1, y2, y3, y4].iter().min().unwrap(),
+            top: *[y1, y2, y3, y4].iter().max().unwrap(),
         }
     }
 
@@ -268,8 +268,8 @@ impl PdfQuadPoints {
     /// Returns the smallest [PdfRect] that can completely enclose the quadrilateral
     /// outlined by this [PdfQuadPoints].
     pub fn to_rect(&self) -> PdfRect {
-        let xs = vec![self.x1, self.x2, self.x3, self.x4];
-        let ys = vec![self.y1, self.y2, self.y3, self.y4];
+        let xs = [self.x1, self.x2, self.x3, self.x4];
+        let ys = [self.y1, self.y2, self.y3, self.y4];
 
         PdfRect::new(
             *ys.iter().min().unwrap(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -171,7 +171,7 @@ pub(crate) mod dates {
             .replace("+00:00'", "Z00'00'")
             .replace(':', "'");
 
-        format!("D:{}{}", date_part, timezone_part)
+        format!("D:{date_part}{timezone_part}")
     }
 }
 


### PR DESCRIPTION
* added form-test images to .gitignore
* fixed `PdfClipPath` unused warning that also showed in `cargo check`
* fixed the rest of the clippy warnings
* checked the unittests