### PR TITLE
feature flagging the `console_log` logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ thread_safe = []
 core_graphics = ["static"]
 paragraph = []
 flatten = []
-console_log = [dep:console_log] # initializes the console_log Logger during initialization
+console_log = ["dep:console_log"] # initializes the console_log Logger during initialization
 
 # By default, pdfium-render uses the latest version of the image crate. To explicitly use
 # an older version, select one of the feature flags below when taking pdfium-render as

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ utf16string = "0"
 vecmath = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-console_log = "1"
+console_log = { version = "1", optional=true }
 console_error_panic_hook = "0"
 js-sys = "0"
 wasm-bindgen = { version = "0", features = ["enable-interning"] }
@@ -77,6 +77,7 @@ thread_safe = []
 core_graphics = ["static"]
 paragraph = []
 flatten = []
+console_log = [dep:console_log] # initializes the console_log Logger during initialization
 
 # By default, pdfium-render uses the latest version of the image crate. To explicitly use
 # an older version, select one of the feature flags below when taking pdfium-render as

--- a/src/bindings/wasm_bindings.rs
+++ b/src/bindings/wasm_bindings.rs
@@ -1031,6 +1031,7 @@ pub fn initialize_pdfium_render(
     local_wasm_module: JsValue,
     debug: bool,
 ) -> bool {
+    #[cfg(feature = "console_log")]
     if console_log::init_with_level(if debug {
         log::Level::Trace
     } else {


### PR DESCRIPTION
This is a very small change that makes initializing the `console_log` logger optional.

In my project, I spent quite some time trying to figure out why my own logging system would not initialize properly.

If you don't want this, feel free to close the PR.

You might want to add 'console_log' to the default features.