### PR TITLE
fix: use explicit lifetimes

### DIFF
--- a/src/pdf/document/page/text.rs
+++ b/src/pdf/document/page/text.rs
@@ -162,7 +162,10 @@ impl<'a> PdfPageText<'a> {
     /// Returns a collection of all the `PdfPageTextChar` characters that lie within the bounds of
     /// the given [PdfRect] in the containing [PdfPage].
     #[inline]
-    pub fn chars_inside_rect(&self, rect: PdfRect) -> Result<PdfPageTextChars<'_>, PdfiumError> {
+    pub fn chars_inside_rect<'b>(
+        &'b self,
+        rect: PdfRect,
+    ) -> Result<PdfPageTextChars<'a>, PdfiumError> {
         let tolerance_x = rect.width() / 2.0;
         let tolerance_y = rect.height() / 2.0;
         let center_height = rect.bottom() + tolerance_y;

--- a/src/pdf/document/page/text.rs
+++ b/src/pdf/document/page/text.rs
@@ -162,10 +162,7 @@ impl<'a> PdfPageText<'a> {
     /// Returns a collection of all the `PdfPageTextChar` characters that lie within the bounds of
     /// the given [PdfRect] in the containing [PdfPage].
     #[inline]
-    pub fn chars_inside_rect<'b>(
-        &'b self,
-        rect: PdfRect,
-    ) -> Result<PdfPageTextChars<'b>, PdfiumError> {
+    pub fn chars_inside_rect(&self, rect: PdfRect) -> Result<PdfPageTextChars<'_>, PdfiumError> {
         let tolerance_x = rect.width() / 2.0;
         let tolerance_y = rect.height() / 2.0;
         let center_height = rect.bottom() + tolerance_y;

--- a/src/pdf/document/page/text.rs
+++ b/src/pdf/document/page/text.rs
@@ -162,7 +162,10 @@ impl<'a> PdfPageText<'a> {
     /// Returns a collection of all the `PdfPageTextChar` characters that lie within the bounds of
     /// the given [PdfRect] in the containing [PdfPage].
     #[inline]
-    pub fn chars_inside_rect(&self, rect: PdfRect) -> Result<PdfPageTextChars<'_>, PdfiumError> {
+    pub fn chars_inside_rect<'b>(
+        &'b self,
+        rect: PdfRect,
+    ) -> Result<PdfPageTextChars<'b>, PdfiumError> {
         let tolerance_x = rect.width() / 2.0;
         let tolerance_y = rect.height() / 2.0;
         let center_height = rect.bottom() + tolerance_y;

--- a/src/pdf/document/page/text/chars.rs
+++ b/src/pdf/document/page/text/chars.rs
@@ -93,7 +93,10 @@ impl<'a> PdfPageTextChars<'a> {
 
     /// Returns a single [PdfPageTextChar] from this [PdfPageTextChars] collection.
     #[inline]
-    pub fn get(&self, index: PdfPageTextCharIndex) -> Result<PdfPageTextChar<'_>, PdfiumError> {
+    pub fn get<'b>(
+        &'b self,
+        index: PdfPageTextCharIndex,
+    ) -> Result<PdfPageTextChar<'a>, PdfiumError> {
         match self.char_indices.get(index) {
             Some(index) => Ok(PdfPageTextChar::from_pdfium(
                 self.document_handle(),

--- a/src/pdf/document/page/text/segment.rs
+++ b/src/pdf/document/page/text/segment.rs
@@ -78,7 +78,7 @@ impl<'a> PdfPageTextSegment<'a> {
     /// and the order in which they appear visually during rendering (and thus the order in
     /// which they are read by a user) may not necessarily match.
     #[inline]
-    pub fn chars(&self) -> Result<PdfPageTextChars<'_>, PdfiumError> {
+    pub fn chars<'b>(&'b self) -> Result<PdfPageTextChars<'a>, PdfiumError> {
         self.text.chars_inside_rect(self.bounds)
     }
 }


### PR DESCRIPTION
## The issue

There is an issue with lifetime inference which prevents legit use of the api:
```rust
use pdfium_render::prelude::*;


struct TextSpan<'a> {
    span: PdfPageTextSegment<'a>,
    chars: PdfPageTextChars<'a>,
}


let page = document.pages().get(0).unwrap();
let text = page.text().unwrap();
let segments = text.segments();
let spans: Vec<TextSpan> = segments
    .iter()
    .map(|span| {
        let chars = { span.chars().unwrap() };
        TextSpanCache {
            span,
            chars,
        }
    })
    .collect();
```

For the above code Rust gives error:
```
error[E0515]: cannot return value referencing function parameter `span`
  --> src/font_size.rs:22:17
   |
20 |                   let chars = { span.chars().unwrap() };
   |                                 ---- `span` is borrowed here
21 |                   let font_size = chars.get(0).unwrap().scaled_font_size();
22 | /                 TextSpanCache {
23 | |                     span,
24 | |                     chars,
25 | |                     font_size,
26 | |                 }
   | |_________________^ returns a value referencing data owned by the current function

error[E0505]: cannot move out of `span` because it is borrowed
  --> src/font_size.rs:23:21
   |
19 |               .map(|span| {
   |                     ----- return type of closure is TextSpanCache<'1>
   |                     |
   |                     binding `span` declared here
20 |                   let chars = { span.chars().unwrap() };
   |                                 ---- borrow of `span` occurs here
21 |                   let font_size = chars.get(0).unwrap().scaled_font_size();
22 | /                 TextSpanCache {
23 | |                     span,
   | |                     ^^^^ move out of `span` occurs here
24 | |                     chars,
25 | |                     font_size,
26 | |                 }
   | |_________________- returning this value requires that `span` is borrowed for `'1`
```

Both `chars` and `span` are capped by lifetime `'a` of a page. `chars` does not depend on `span` value: it does not contain any references to a `span`:
```rust
pub struct PdfPageTextChars<'a> {
    document_handle: FPDF_DOCUMENT,
    page_handle: FPDF_PAGE,
    text_page_handle: FPDF_TEXTPAGE,
    char_indices: Vec<i32>,
    lifetime: PhantomData<&'a FPDF_TEXTPAGE>, // reference to a page
}
```

## The root cause

There is incorrect inference of lifetimes for returned values. 

Given the old signature (without elided lifetimes):
```rust
impl<'a> PdfPageTextSegment<'a> {
  pub fn chars(&'1 self) -> Result<PdfPageTextChars<'_>, PdfiumError> { /* ... */ }
}
```

rust erroneously  assumes `'_` to be `'1` instead of `'a`.

## The solution

The implemented solution indicates lifetimes explicitly:
``` rust
impl<'a> PdfPageTextSegment<'a> {
  pub fn chars(&'b self) -> Result<PdfPageTextChars<'a>, PdfiumError> { /* ... */ }
}
```
It does unbound `PdfPageTextChars` lifetime from `PdfPageTextSegment`'s lifetime.

This PR fixes only two methods. The same issue may be present in other methods
