### PR TITLE
Add PdfRenderConfig::set_auto_apply_intrinsic_rotation for matrix path

### DIFF
--- a/src/pdf/document/page/render_config.rs
+++ b/src/pdf/document/page/render_config.rs
@@ -52,6 +52,16 @@ pub struct PdfRenderConfig {
     form_field_highlight: Option<Vec<(PdfFormFieldType, PdfColor)>>,
     transformation_matrix: PdfMatrix,
     clip_rect: Option<(Pixels, Pixels, Pixels, Pixels)>,
+    /// When `true`, the matrix render path composes the page's intrinsic
+    /// `/Rotate` with [`Self::transformation_matrix`] before passing the
+    /// result to `FPDF_RenderPageBitmapWithMatrix`. Lets matrix-path
+    /// callers write their transform in display-oriented coordinates
+    /// (the same coordinate system the form-data path speaks) instead
+    /// of hand-deriving a per-`/Rotate` matrix. Default `false` —
+    /// existing callers supply a matrix in pre-rotation page coordinates
+    /// and changing that under their feet would silently flip output for
+    /// every rotated PDF.
+    auto_apply_intrinsic_rotation: bool,
 
     // The fields below set Pdfium's page rendering flags. Coverage for the
     // FPDF_DEBUG_INFO and FPDF_NO_CATCH flags is omitted since they are obsolete.
@@ -93,6 +103,7 @@ impl PdfRenderConfig {
             form_field_highlight: None,
             transformation_matrix: PdfMatrix::IDENTITY,
             clip_rect: None,
+            auto_apply_intrinsic_rotation: false,
             do_set_flag_render_annotations: true,
             do_set_flag_use_lcd_text_rendering: false,
             do_set_flag_no_native_text: false,
@@ -652,6 +663,33 @@ impl PdfRenderConfig {
         self
     }
 
+    /// Controls whether the matrix render path composes the page's intrinsic
+    /// `/Rotate` with any matrix supplied via [`Self::transform()`] /
+    /// [`Self::reset_matrix()`] before passing the result to
+    /// `FPDF_RenderPageBitmapWithMatrix`.
+    ///
+    /// The form-data render path (`FPDF_RenderPageBitmap`) always honours
+    /// the page's `/Rotate` automatically. The matrix render path does
+    /// not — every caller using a custom transformation on a page with a
+    /// non-zero `/Rotate` has to hand-derive a per-`/Rotate` matrix that
+    /// bakes the rotation into the transform itself. Setting this flag
+    /// to `true` lets callers write their transform in **display-oriented**
+    /// page coordinates (the same coordinate system the form-data path
+    /// speaks) and have the rotation applied for them.
+    ///
+    /// Default is `false` to preserve existing matrix-path semantics —
+    /// every existing user supplies a matrix in pre-rotation page
+    /// coordinates, and changing that under their feet would silently
+    /// flip output for every rotated PDF in the wild.
+    ///
+    /// Has no effect when the form-data path is in use.
+    #[inline]
+    pub fn set_auto_apply_intrinsic_rotation(mut self, yes: bool) -> Self {
+        self.auto_apply_intrinsic_rotation = yes;
+
+        self
+    }
+
     /// Computes the pixel dimensions and rotation settings for the given [PdfPage]
     /// based on the configuration of this [PdfRenderConfig].
     #[inline]
@@ -839,6 +877,36 @@ impl PdfRenderConfig {
         // 90-degree rotation need to be applied to the transformation matrix now.
 
         let transformation_matrix = if !self.do_render_form_data {
+            // If `auto_apply_intrinsic_rotation` is set, pre-compose the page's
+            // `/Rotate` mapping with the user-supplied matrix. The user's matrix
+            // is then interpreted as operating on display-oriented coordinates
+            // — the same coordinate system the form-data path speaks — rather
+            // than pre-rotation page coordinates that the matrix render path
+            // would otherwise expect.
+            let starting_matrix = if self.auto_apply_intrinsic_rotation {
+                let intrinsic = page.rotation().unwrap_or(PdfPageRenderRotation::None);
+
+                if intrinsic != PdfPageRenderRotation::None {
+                    // `source_width` / `source_height` come from `page.width()` /
+                    // `page.height()` which return display-oriented dims (already
+                    // swapped for `/Rotate 90/270`). Recover the pre-rotation dims
+                    // for the `R` matrix.
+                    let (pre_w, pre_h) = match intrinsic {
+                        PdfPageRenderRotation::Degrees90 | PdfPageRenderRotation::Degrees270 => {
+                            (source_height.value, source_width.value)
+                        }
+                        _ => (source_width.value, source_height.value),
+                    };
+
+                    intrinsic_rotation_matrix(intrinsic, pre_w, pre_h)
+                        .multiply(self.transformation_matrix)
+                } else {
+                    self.transformation_matrix
+                }
+            } else {
+                self.transformation_matrix
+            };
+
             let result = if target_rotation != PdfPageRenderRotation::None {
                 // Translate the origin to the center of the page before rotating.
 
@@ -849,13 +917,13 @@ impl PdfRenderConfig {
                     PdfPageRenderRotation::Degrees270 => (-source_height, PdfPoints::ZERO),
                 };
 
-                self.transformation_matrix
+                starting_matrix
                     .translate(delta_x, delta_y)
                     .and_then(|result| {
                         result.rotate_clockwise_degrees(target_rotation.as_degrees())
                     })
             } else {
-                Ok(self.transformation_matrix)
+                Ok(starting_matrix)
             };
 
             result.and_then(|result| result.scale(width_scale, height_scale))
@@ -918,6 +986,32 @@ impl Default for PdfRenderConfig {
     #[inline]
     fn default() -> Self {
         PdfRenderConfig::new()
+    }
+}
+
+/// Returns the PDF transformation matrix mapping pre-rotation page coordinates
+/// (PDF user space, y-up, origin bottom-left) to display-oriented page
+/// coordinates (still PDF user space, y-up, but with the page rotated to
+/// match its `/Rotate` value). `pre_w` / `pre_h` are pre-rotation page
+/// dimensions in PDF points.
+///
+/// Composing this matrix with a display-oriented user matrix via
+/// [`PdfMatrix::multiply`] produces the full pre-rotation → bitmap matrix
+/// that `FPDF_RenderPageBitmapWithMatrix` expects, so callers don't have to
+/// hand-derive a per-`/Rotate` matrix.
+fn intrinsic_rotation_matrix(
+    rotation: PdfPageRenderRotation,
+    pre_w: PdfMatrixValue,
+    pre_h: PdfMatrixValue,
+) -> PdfMatrix {
+    match rotation {
+        PdfPageRenderRotation::None => PdfMatrix::IDENTITY,
+        // /Rotate 90 cw: pre-rotation (x, y) -> display (y, w_pre - x).
+        PdfPageRenderRotation::Degrees90 => PdfMatrix::new(0.0, -1.0, 1.0, 0.0, 0.0, pre_w),
+        // /Rotate 180: pre-rotation (x, y) -> display (w_pre - x, h_pre - y).
+        PdfPageRenderRotation::Degrees180 => PdfMatrix::new(-1.0, 0.0, 0.0, -1.0, pre_w, pre_h),
+        // /Rotate 270 cw (== 90 ccw): pre-rotation (x, y) -> display (h_pre - y, x).
+        PdfPageRenderRotation::Degrees270 => PdfMatrix::new(0.0, 1.0, -1.0, 0.0, pre_h, 0.0),
     }
 }
 
@@ -1000,5 +1094,175 @@ mod tests {
             .create_page_at_start(PdfPagePaperSize::Portrait(PdfPagePaperStandardSize::A4))?;
 
         Ok(config.apply_to_page(&page))
+    }
+
+    // ---------------------------------------------------------------------
+    // auto_apply_intrinsic_rotation tests.
+    //
+    // The flag is a one-bool switch on the matrix render path that pre-
+    // composes the page's intrinsic `/Rotate` with any caller-supplied
+    // matrix, so callers don't have to hand-derive a per-`/Rotate` matrix.
+    // The tests below pin:
+    //
+    //   1. Default-off: emits the identical matrix as before.
+    //   2. On a /Rotate 0 page: composing identity changes nothing.
+    //   3. On a /Rotate 90/180/270 page: produces the matrix that maps
+    //      pre-rotation page coords → display-oriented coords, composed
+    //      with the user matrix in the right order.
+    //
+    // Tests (1)–(3) live below. Render-level integration coverage
+    // (matrix-path-with-auto-rotate ≡ form-data-path baseline) is left to
+    // downstream consumers like libviprs's `pdfium_streaming_rotation_matrix`
+    // cross-product test, which already pins it for the four /Rotate values
+    // against pdfium's own form-data rasterizer.
+    // ---------------------------------------------------------------------
+
+    /// Builds a matrix-path config (form data disabled) so apply_to_page
+    /// runs through the auto-rotate branch.
+    fn matrix_path_config_with(matrix: PdfMatrix) -> PdfRenderConfig {
+        PdfRenderConfig::new()
+            .render_form_data(false)
+            .reset_matrix(matrix)
+            .unwrap()
+    }
+
+    #[test]
+    fn test_auto_apply_intrinsic_rotation_default_false() -> Result<(), PdfiumError> {
+        // The default must be off. Flipping it under existing callers'
+        // feet would silently change the bytes their matrix-path renders
+        // produce on every rotated PDF in the wild.
+        assert!(!PdfRenderConfig::new().auto_apply_intrinsic_rotation);
+        Ok(())
+    }
+
+    #[test]
+    fn test_auto_apply_intrinsic_rotation_on_zero_rotate_page_is_identity(
+    ) -> Result<(), PdfiumError> {
+        // Composing identity must change nothing. Same input, same output.
+        let pdfium = test_bind_to_pdfium();
+        let mut document = pdfium.create_new_pdf()?;
+        let page = document
+            .pages_mut()
+            .create_page_at_start(PdfPagePaperSize::Portrait(PdfPagePaperStandardSize::A4))?;
+        assert_eq!(page.rotation()?, PdfPageRenderRotation::None);
+
+        let user = PdfMatrix::IDENTITY.scale(2.0, 3.0)?;
+        let m_off = matrix_path_config_with(user).apply_to_page(&page).matrix;
+        let m_on = matrix_path_config_with(user)
+            .set_auto_apply_intrinsic_rotation(true)
+            .apply_to_page(&page)
+            .matrix;
+        assert_eq!(
+            (m_off.a, m_off.b, m_off.c, m_off.d, m_off.e, m_off.f),
+            (m_on.a, m_on.b, m_on.c, m_on.d, m_on.e, m_on.f)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_auto_apply_intrinsic_rotation_composes_for_each_rotate_value() -> Result<(), PdfiumError>
+    {
+        // For each /Rotate ∈ {90, 180, 270}, set the page's rotation
+        // and assert apply_to_page emits the expected pre-composed
+        // matrix. This is the bug-pinning anchor for the rotation
+        // matrix derivation.
+        //
+        // The user matrix is identity so apply_to_page emits exactly
+        // `R` (the intrinsic rotation matrix) — easy to read off.
+        let pdfium = test_bind_to_pdfium();
+        let mut document = pdfium.create_new_pdf()?;
+        let mut page = document
+            .pages_mut()
+            .create_page_at_start(PdfPagePaperSize::Portrait(PdfPagePaperStandardSize::A4))?;
+
+        // Pre-rotation A4 dims in pt.
+        let pre_w = page.width().value;
+        let pre_h = page.height().value;
+
+        let cases = [
+            // (rotation, expected R = [a, b, c, d, e, f])
+            (
+                PdfPageRenderRotation::Degrees90,
+                [0.0, -1.0, 1.0, 0.0, 0.0, pre_w],
+            ),
+            (
+                PdfPageRenderRotation::Degrees180,
+                [-1.0, 0.0, 0.0, -1.0, pre_w, pre_h],
+            ),
+            (
+                PdfPageRenderRotation::Degrees270,
+                [0.0, 1.0, -1.0, 0.0, pre_h, 0.0],
+            ),
+        ];
+
+        for (rotation, expected) in cases {
+            page.set_rotation(rotation);
+            assert_eq!(page.rotation()?, rotation);
+
+            let m = matrix_path_config_with(PdfMatrix::IDENTITY)
+                .set_auto_apply_intrinsic_rotation(true)
+                .apply_to_page(&page)
+                .matrix;
+
+            let actual = [m.a, m.b, m.c, m.d, m.e, m.f];
+            for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+                assert!(
+                    (a - e).abs() < 1e-3,
+                    "/Rotate {:?}: matrix component {} diverged: {} vs expected {}",
+                    rotation,
+                    i,
+                    a,
+                    e,
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_auto_apply_intrinsic_rotation_composes_user_matrix_after_rotation(
+    ) -> Result<(), PdfiumError> {
+        // User matrix ∘ R ordering: R applied first (pre-rotation -> display),
+        // user matrix applied second (display -> bitmap). For /Rotate 90 the
+        // libviprs strip-matrix derivation gives, with user = display->pixel
+        // [s, 0, 0, -s, 0, s·display_h_pt - y_off]:
+        //   composed = [0, s, s, 0, 0, -y_off]
+        // We pin one such composition here.
+        let pdfium = test_bind_to_pdfium();
+        let mut document = pdfium.create_new_pdf()?;
+        let mut page = document
+            .pages_mut()
+            .create_page_at_start(PdfPagePaperSize::Portrait(PdfPagePaperStandardSize::A4))?;
+        page.set_rotation(PdfPageRenderRotation::Degrees90);
+
+        // Pre-rotation height is the configured PdfPage height (we set
+        // /Rotate 90 *after* page creation, so width()/height() now
+        // return display-oriented = swapped dims). Pre-rotation w == display h.
+        // Pre-rotation A4: 595 × 842 pt. Display under /Rotate 90: 842 × 595.
+        let display_h_pt = page.height().value; // 595
+        let s: f32 = 2.0;
+        let y_off: f32 = 100.0;
+
+        // user matrix: display-oriented (y-up) -> bitmap pixel (y-down) with strip offset.
+        let user = PdfMatrix::new(s, 0.0, 0.0, -s, 0.0, s * display_h_pt - y_off);
+
+        let m = matrix_path_config_with(user)
+            .set_auto_apply_intrinsic_rotation(true)
+            .apply_to_page(&page)
+            .matrix;
+
+        // Expected per libviprs derivation: [0, s, s, 0, 0, -y_off].
+        let expected = [0.0, s, s, 0.0, 0.0, -y_off];
+        let actual = [m.a, m.b, m.c, m.d, m.e, m.f];
+        for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (a - e).abs() < 1e-3,
+                "matrix component {} diverged: {} vs expected {}",
+                i,
+                a,
+                e,
+            );
+        }
+        Ok(())
     }
 }

--- a/src/pdf/document/page/render_config.rs
+++ b/src/pdf/document/page/render_config.rs
@@ -1309,8 +1309,8 @@ mod tests {
         let m_flag = PdfRenderConfig::new()
             .render_form_data(false)
             .reset_matrix(user)?
-            .rotate(PdfPageRenderRotation::Degrees90, false)
             .set_auto_apply_intrinsic_rotation(true)
+            .rotate(PdfPageRenderRotation::Degrees90, false)
             .apply_to_page(&page)
             .matrix;
 

--- a/src/pdf/document/page/render_config.rs
+++ b/src/pdf/document/page/render_config.rs
@@ -1265,4 +1265,68 @@ mod tests {
         }
         Ok(())
     }
+
+    #[test]
+    fn test_auto_apply_intrinsic_rotation_composes_with_target_rotation() -> Result<(), PdfiumError>
+    {
+        // When the flag is on AND `.rotate(...)` also asks for additional
+        // rotation, the composed matrix must equal the matrix you'd get
+        // by manually pre-composing R into the user matrix yourself and
+        // letting the existing `target_rotation` translate+rotate path
+        // run on top. Pins the order: R first, user_matrix second,
+        // `target_rotation` translate+rotate third, scale fourth.
+        //
+        // Equivalence-via-manual-precomposition is the cleanest way to
+        // pin this — it doesn't depend on guessing the final matrix
+        // arithmetic, only on "the flag is exactly the manual step."
+        let pdfium = test_bind_to_pdfium();
+        let mut document = pdfium.create_new_pdf()?;
+        let mut page = document
+            .pages_mut()
+            .create_page_at_start(PdfPagePaperSize::Portrait(PdfPagePaperStandardSize::A4))?;
+        page.set_rotation(PdfPageRenderRotation::Degrees90);
+
+        // Non-trivial user matrix so the test isn't trivially satisfied
+        // by R alone.
+        let user = PdfMatrix::IDENTITY.scale(2.0, 3.0)?;
+
+        // Manual pre-composition: R for /Rotate 90 with pre_w = display_h.
+        let pre_w = page.height().value;
+        let r = PdfMatrix::new(0.0, -1.0, 1.0, 0.0, 0.0, pre_w);
+        let pre_composed = r.multiply(user);
+
+        // Both configs add `.rotate(Degrees90, false)` for additional
+        // caller rotation — a deliberately different value from the
+        // page's intrinsic /Rotate so we can tell they're composing
+        // independently rather than collapsing.
+        let m_manual = PdfRenderConfig::new()
+            .render_form_data(false)
+            .reset_matrix(pre_composed)?
+            .rotate(PdfPageRenderRotation::Degrees90, false)
+            .apply_to_page(&page)
+            .matrix;
+
+        let m_flag = PdfRenderConfig::new()
+            .render_form_data(false)
+            .reset_matrix(user)?
+            .rotate(PdfPageRenderRotation::Degrees90, false)
+            .set_auto_apply_intrinsic_rotation(true)
+            .apply_to_page(&page)
+            .matrix;
+
+        let actual = [m_flag.a, m_flag.b, m_flag.c, m_flag.d, m_flag.e, m_flag.f];
+        let expected = [
+            m_manual.a, m_manual.b, m_manual.c, m_manual.d, m_manual.e, m_manual.f,
+        ];
+        for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (a - e).abs() < 1e-3,
+                "matrix component {} diverged: flag={}, manual={}",
+                i,
+                a,
+                e,
+            );
+        }
+        Ok(())
+    }
 }

--- a/src/pdf/document/page/render_config.rs
+++ b/src/pdf/document/page/render_config.rs
@@ -1407,4 +1407,68 @@ mod tests {
         }
         Ok(())
     }
+
+    #[test]
+    fn test_auto_apply_intrinsic_rotation_composes_with_target_rotation() -> Result<(), PdfiumError>
+    {
+        // When the flag is on AND `.rotate(...)` also asks for additional
+        // rotation, the composed matrix must equal the matrix you'd get
+        // by manually pre-composing R into the user matrix yourself and
+        // letting the existing `target_rotation` translate+rotate path
+        // run on top. Pins the order: R first, user_matrix second,
+        // `target_rotation` translate+rotate third, scale fourth.
+        //
+        // Equivalence-via-manual-precomposition is the cleanest way to
+        // pin this — it doesn't depend on guessing the final matrix
+        // arithmetic, only on "the flag is exactly the manual step."
+        let pdfium = test_bind_to_pdfium();
+        let mut document = pdfium.create_new_pdf()?;
+        let mut page = document
+            .pages_mut()
+            .create_page_at_start(PdfPagePaperSize::Portrait(PdfPagePaperStandardSize::A4))?;
+        page.set_rotation(PdfPageRenderRotation::Degrees90);
+
+        // Non-trivial user matrix so the test isn't trivially satisfied
+        // by R alone.
+        let user = PdfMatrix::IDENTITY.scale(2.0, 3.0)?;
+
+        // Manual pre-composition: R for /Rotate 90 with pre_w = display_h.
+        let pre_w = page.height().value;
+        let r = PdfMatrix::new(0.0, -1.0, 1.0, 0.0, 0.0, pre_w);
+        let pre_composed = r.multiply(user);
+
+        // Both configs add `.rotate(Degrees90, false)` for additional
+        // caller rotation — a deliberately different value from the
+        // page's intrinsic /Rotate so we can tell they're composing
+        // independently rather than collapsing.
+        let m_manual = PdfRenderConfig::new()
+            .render_form_data(false)
+            .reset_matrix(pre_composed)?
+            .rotate(PdfPageRenderRotation::Degrees90, false)
+            .apply_to_page(&page)
+            .matrix;
+
+        let m_flag = PdfRenderConfig::new()
+            .render_form_data(false)
+            .reset_matrix(user)?
+            .rotate(PdfPageRenderRotation::Degrees90, false)
+            .set_auto_apply_intrinsic_rotation(true)
+            .apply_to_page(&page)
+            .matrix;
+
+        let actual = [m_flag.a, m_flag.b, m_flag.c, m_flag.d, m_flag.e, m_flag.f];
+        let expected = [
+            m_manual.a, m_manual.b, m_manual.c, m_manual.d, m_manual.e, m_manual.f,
+        ];
+        for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (a - e).abs() < 1e-3,
+                "matrix component {} diverged: flag={}, manual={}",
+                i,
+                a,
+                e,
+            );
+        }
+        Ok(())
+    }
 }

--- a/src/pdf/document/page/render_config.rs
+++ b/src/pdf/document/page/render_config.rs
@@ -1451,8 +1451,8 @@ mod tests {
         let m_flag = PdfRenderConfig::new()
             .render_form_data(false)
             .reset_matrix(user)?
-            .rotate(PdfPageRenderRotation::Degrees90, false)
             .set_auto_apply_intrinsic_rotation(true)
+            .rotate(PdfPageRenderRotation::Degrees90, false)
             .apply_to_page(&page)
             .matrix;
 

--- a/src/pdf/document/page/render_config.rs
+++ b/src/pdf/document/page/render_config.rs
@@ -1471,4 +1471,125 @@ mod tests {
         }
         Ok(())
     }
+
+    #[test]
+    fn test_auto_apply_intrinsic_rotation_maps_corners_by_geometric_oracle(
+    ) -> Result<(), PdfiumError> {
+        // Independent geometric oracle for the intrinsic-`/Rotate` matrix.
+        //
+        // The other tests in this module assert the emitted matrix equals a
+        // hand-written `R = [a, b, c, d, e, f]` literal. For /Rotate 180 and
+        // 270 those literals are simply copied from the source, so a sign
+        // flip, an axis/dimension swap, or a wrong translation term baked
+        // into `R` would be copied into the expectation too and the test
+        // would still pass. This test never references `R`. It derives where
+        // the page corners must land from first principles — rotate each
+        // pre-rotation corner clockwise by the `/Rotate` angle, translate the
+        // rotated page back into the positive quadrant (its displayed
+        // position in y-up user space), then apply the caller's
+        // display-oriented matrix — and checks that the matrix
+        // `apply_to_page` actually emits maps the same corners to the same
+        // places. A wrong `R_180`/`R_270` moves at least one corner by
+        // hundreds of points, far outside the epsilon.
+
+        let pdfium = test_bind_to_pdfium();
+        let mut document = pdfium.create_new_pdf()?;
+        let mut page = document
+            .pages_mut()
+            .create_page_at_start(PdfPagePaperSize::Portrait(PdfPagePaperStandardSize::A4))?;
+
+        // Pre-rotation A4 dims in points. Read them now, before any `/Rotate`
+        // is set: once a 90/270 rotation is applied, `width()`/`height()`
+        // return display-oriented (swapped) dims. A4 is non-square (595 x
+        // 842), so a width/height swap in `R` cannot hide.
+        let pre_w = page.width().value;
+        let pre_h = page.height().value;
+        assert!(
+            (pre_w - pre_h).abs() > 1.0,
+            "oracle needs a non-square page to expose axis swaps",
+        );
+
+        // A deliberately non-identity, non-symmetric caller matrix: distinct
+        // x/y scale plus a translation. Row-vector apply per the PDF
+        // convention: (x, y) -> (a*x + c*y + e, b*x + d*y + f).
+        let (ua, ub, uc, ud, ue, uf) = (2.0_f32, 0.0_f32, 0.0_f32, 3.0_f32, 17.0_f32, 29.0_f32);
+        let user = PdfMatrix::new(ua, ub, uc, ud, ue, uf);
+
+        // The four pre-rotation page corners, in points.
+        let corners = [
+            (0.0_f32, 0.0_f32),
+            (pre_w, 0.0),
+            (pre_w, pre_h),
+            (0.0, pre_h),
+        ];
+
+        // Generic clockwise rotation of a point about the origin in a y-up
+        // plane, derived independently of `R`: CW by theta maps (x, y) to
+        // (x*cos(theta) + y*sin(theta), -x*sin(theta) + y*cos(theta)).
+        fn rotate_cw(x: f32, y: f32, degrees: i32) -> (f32, f32) {
+            let (sin, cos) = (degrees as f64).to_radians().sin_cos();
+            let (x, y) = (x as f64, y as f64);
+            ((x * cos + y * sin) as f32, (-x * sin + y * cos) as f32)
+        }
+
+        for degrees in [90, 180, 270] {
+            let rotation = match degrees {
+                90 => PdfPageRenderRotation::Degrees90,
+                180 => PdfPageRenderRotation::Degrees180,
+                _ => PdfPageRenderRotation::Degrees270,
+            };
+            page.set_rotation(rotation);
+            assert_eq!(page.rotation()?, rotation);
+
+            // --- Oracle: where each corner MUST land, from first principles. ---
+
+            // 1. Rotate every corner clockwise about the origin.
+            let rotated: Vec<(f32, f32)> = corners
+                .iter()
+                .map(|&(x, y)| rotate_cw(x, y, degrees))
+                .collect();
+
+            // 2. Translate the rotated page back into the positive quadrant so
+            //    its bottom-left corner sits at the origin — this is what the
+            //    intrinsic `/Rotate` does: the displayed page occupies
+            //    [0, w] x [0, h] in y-up user space.
+            let min_x = rotated.iter().map(|p| p.0).fold(f32::INFINITY, f32::min);
+            let min_y = rotated.iter().map(|p| p.1).fold(f32::INFINITY, f32::min);
+
+            // 3. Apply the caller's display-oriented matrix to obtain the
+            //    expected bitmap coords.
+            let expected: Vec<(f32, f32)> = rotated
+                .iter()
+                .map(|&(rx, ry)| {
+                    let (dx, dy) = (rx - min_x, ry - min_y);
+                    (ua * dx + uc * dy + ue, ub * dx + ud * dy + uf)
+                })
+                .collect();
+
+            // --- Actual: apply the emitted matrix to the same corners. ---
+            let m = matrix_path_config_with(user)
+                .set_auto_apply_intrinsic_rotation(true)
+                .apply_to_page(&page)
+                .matrix;
+
+            let actual: Vec<(f32, f32)> = corners
+                .iter()
+                .map(|&(x, y)| (m.a * x + m.c * y + m.e, m.b * x + m.d * y + m.f))
+                .collect();
+
+            for (i, (exp, act)) in expected.iter().zip(actual.iter()).enumerate() {
+                assert!(
+                    (exp.0 - act.0).abs() < 1e-2 && (exp.1 - act.1).abs() < 1e-2,
+                    "/Rotate {}: corner {} {:?} maps to {:?}, expected {:?}",
+                    degrees,
+                    i,
+                    corners[i],
+                    act,
+                    exp,
+                );
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/src/pdf/document/page/render_config.rs
+++ b/src/pdf/document/page/render_config.rs
@@ -54,6 +54,16 @@ pub struct PdfRenderConfig {
     form_field_highlight: Option<Vec<(PdfFormFieldType, PdfColor)>>,
     transformation_matrix: PdfMatrix,
     clip_rect: Option<(Pixels, Pixels, Pixels, Pixels)>,
+    /// When `true`, the matrix render path composes the page's intrinsic
+    /// `/Rotate` with [`Self::transformation_matrix`] before passing the
+    /// result to `FPDF_RenderPageBitmapWithMatrix`. Lets matrix-path
+    /// callers write their transform in display-oriented coordinates
+    /// (the same coordinate system the form-data path speaks) instead
+    /// of hand-deriving a per-`/Rotate` matrix. Default `false` —
+    /// existing callers supply a matrix in pre-rotation page coordinates
+    /// and changing that under their feet would silently flip output for
+    /// every rotated PDF.
+    auto_apply_intrinsic_rotation: bool,
 
     // The fields below set Pdfium's page rendering flags. Coverage for the
     // FPDF_DEBUG_INFO and FPDF_NO_CATCH flags is omitted since they are obsolete.
@@ -97,6 +107,7 @@ impl PdfRenderConfig {
             form_field_highlight: None,
             transformation_matrix: PdfMatrix::IDENTITY,
             clip_rect: None,
+            auto_apply_intrinsic_rotation: false,
             do_set_flag_render_annotations: true,
             do_set_flag_use_lcd_text_rendering: false,
             do_set_flag_no_native_text: false,
@@ -682,6 +693,33 @@ impl PdfRenderConfig {
         self
     }
 
+    /// Controls whether the matrix render path composes the page's intrinsic
+    /// `/Rotate` with any matrix supplied via [`Self::transform()`] /
+    /// [`Self::reset_matrix()`] before passing the result to
+    /// `FPDF_RenderPageBitmapWithMatrix`.
+    ///
+    /// The form-data render path (`FPDF_RenderPageBitmap`) always honours
+    /// the page's `/Rotate` automatically. The matrix render path does
+    /// not — every caller using a custom transformation on a page with a
+    /// non-zero `/Rotate` has to hand-derive a per-`/Rotate` matrix that
+    /// bakes the rotation into the transform itself. Setting this flag
+    /// to `true` lets callers write their transform in **display-oriented**
+    /// page coordinates (the same coordinate system the form-data path
+    /// speaks) and have the rotation applied for them.
+    ///
+    /// Default is `false` to preserve existing matrix-path semantics —
+    /// every existing user supplies a matrix in pre-rotation page
+    /// coordinates, and changing that under their feet would silently
+    /// flip output for every rotated PDF in the wild.
+    ///
+    /// Has no effect when the form-data path is in use.
+    #[inline]
+    pub fn set_auto_apply_intrinsic_rotation(mut self, yes: bool) -> Self {
+        self.auto_apply_intrinsic_rotation = yes;
+
+        self
+    }
+
     /// Computes the pixel dimensions and rotation settings for the given [PdfPage]
     /// based on the configuration of this [PdfRenderConfig].
     #[inline]
@@ -869,6 +907,36 @@ impl PdfRenderConfig {
         // 90-degree rotation need to be applied to the transformation matrix now.
 
         let transformation_matrix = if !self.do_render_form_data {
+            // If `auto_apply_intrinsic_rotation` is set, pre-compose the page's
+            // `/Rotate` mapping with the user-supplied matrix. The user's matrix
+            // is then interpreted as operating on display-oriented coordinates
+            // — the same coordinate system the form-data path speaks — rather
+            // than pre-rotation page coordinates that the matrix render path
+            // would otherwise expect.
+            let starting_matrix = if self.auto_apply_intrinsic_rotation {
+                let intrinsic = page.rotation().unwrap_or(PdfPageRenderRotation::None);
+
+                if intrinsic != PdfPageRenderRotation::None {
+                    // `source_width` / `source_height` come from `page.width()` /
+                    // `page.height()` which return display-oriented dims (already
+                    // swapped for `/Rotate 90/270`). Recover the pre-rotation dims
+                    // for the `R` matrix.
+                    let (pre_w, pre_h) = match intrinsic {
+                        PdfPageRenderRotation::Degrees90 | PdfPageRenderRotation::Degrees270 => {
+                            (source_height.value, source_width.value)
+                        }
+                        _ => (source_width.value, source_height.value),
+                    };
+
+                    intrinsic_rotation_matrix(intrinsic, pre_w, pre_h)
+                        .multiply(self.transformation_matrix)
+                } else {
+                    self.transformation_matrix
+                }
+            } else {
+                self.transformation_matrix
+            };
+
             let result = if target_rotation != PdfPageRenderRotation::None {
                 // Translate the origin to the center of the page before rotating.
 
@@ -879,13 +947,13 @@ impl PdfRenderConfig {
                     PdfPageRenderRotation::Degrees270 => (-source_height, PdfPoints::ZERO),
                 };
 
-                self.transformation_matrix
+                starting_matrix
                     .translate(delta_x, delta_y)
                     .and_then(|result| {
                         result.rotate_clockwise_degrees(target_rotation.as_degrees())
                     })
             } else {
-                Ok(self.transformation_matrix)
+                Ok(starting_matrix)
             };
 
             result.and_then(|result| result.scale(width_scale, height_scale))
@@ -950,6 +1018,32 @@ impl Default for PdfRenderConfig {
     #[inline]
     fn default() -> Self {
         PdfRenderConfig::new()
+    }
+}
+
+/// Returns the PDF transformation matrix mapping pre-rotation page coordinates
+/// (PDF user space, y-up, origin bottom-left) to display-oriented page
+/// coordinates (still PDF user space, y-up, but with the page rotated to
+/// match its `/Rotate` value). `pre_w` / `pre_h` are pre-rotation page
+/// dimensions in PDF points.
+///
+/// Composing this matrix with a display-oriented user matrix via
+/// [`PdfMatrix::multiply`] produces the full pre-rotation → bitmap matrix
+/// that `FPDF_RenderPageBitmapWithMatrix` expects, so callers don't have to
+/// hand-derive a per-`/Rotate` matrix.
+fn intrinsic_rotation_matrix(
+    rotation: PdfPageRenderRotation,
+    pre_w: PdfMatrixValue,
+    pre_h: PdfMatrixValue,
+) -> PdfMatrix {
+    match rotation {
+        PdfPageRenderRotation::None => PdfMatrix::IDENTITY,
+        // /Rotate 90 cw: pre-rotation (x, y) -> display (y, w_pre - x).
+        PdfPageRenderRotation::Degrees90 => PdfMatrix::new(0.0, -1.0, 1.0, 0.0, 0.0, pre_w),
+        // /Rotate 180: pre-rotation (x, y) -> display (w_pre - x, h_pre - y).
+        PdfPageRenderRotation::Degrees180 => PdfMatrix::new(-1.0, 0.0, 0.0, -1.0, pre_w, pre_h),
+        // /Rotate 270 cw (== 90 ccw): pre-rotation (x, y) -> display (h_pre - y, x).
+        PdfPageRenderRotation::Degrees270 => PdfMatrix::new(0.0, 1.0, -1.0, 0.0, pre_h, 0.0),
     }
 }
 
@@ -1142,5 +1236,175 @@ mod tests {
             .create_page_at_start(PdfPagePaperSize::Portrait(PdfPagePaperStandardSize::A4))?;
 
         Ok(config.apply_to_page(&page))
+    }
+
+    // ---------------------------------------------------------------------
+    // auto_apply_intrinsic_rotation tests.
+    //
+    // The flag is a one-bool switch on the matrix render path that pre-
+    // composes the page's intrinsic `/Rotate` with any caller-supplied
+    // matrix, so callers don't have to hand-derive a per-`/Rotate` matrix.
+    // The tests below pin:
+    //
+    //   1. Default-off: emits the identical matrix as before.
+    //   2. On a /Rotate 0 page: composing identity changes nothing.
+    //   3. On a /Rotate 90/180/270 page: produces the matrix that maps
+    //      pre-rotation page coords → display-oriented coords, composed
+    //      with the user matrix in the right order.
+    //
+    // Tests (1)–(3) live below. Render-level integration coverage
+    // (matrix-path-with-auto-rotate ≡ form-data-path baseline) is left to
+    // downstream consumers like libviprs's `pdfium_streaming_rotation_matrix`
+    // cross-product test, which already pins it for the four /Rotate values
+    // against pdfium's own form-data rasterizer.
+    // ---------------------------------------------------------------------
+
+    /// Builds a matrix-path config (form data disabled) so apply_to_page
+    /// runs through the auto-rotate branch.
+    fn matrix_path_config_with(matrix: PdfMatrix) -> PdfRenderConfig {
+        PdfRenderConfig::new()
+            .render_form_data(false)
+            .reset_matrix(matrix)
+            .unwrap()
+    }
+
+    #[test]
+    fn test_auto_apply_intrinsic_rotation_default_false() -> Result<(), PdfiumError> {
+        // The default must be off. Flipping it under existing callers'
+        // feet would silently change the bytes their matrix-path renders
+        // produce on every rotated PDF in the wild.
+        assert!(!PdfRenderConfig::new().auto_apply_intrinsic_rotation);
+        Ok(())
+    }
+
+    #[test]
+    fn test_auto_apply_intrinsic_rotation_on_zero_rotate_page_is_identity(
+    ) -> Result<(), PdfiumError> {
+        // Composing identity must change nothing. Same input, same output.
+        let pdfium = test_bind_to_pdfium();
+        let mut document = pdfium.create_new_pdf()?;
+        let page = document
+            .pages_mut()
+            .create_page_at_start(PdfPagePaperSize::Portrait(PdfPagePaperStandardSize::A4))?;
+        assert_eq!(page.rotation()?, PdfPageRenderRotation::None);
+
+        let user = PdfMatrix::IDENTITY.scale(2.0, 3.0)?;
+        let m_off = matrix_path_config_with(user).apply_to_page(&page).matrix;
+        let m_on = matrix_path_config_with(user)
+            .set_auto_apply_intrinsic_rotation(true)
+            .apply_to_page(&page)
+            .matrix;
+        assert_eq!(
+            (m_off.a, m_off.b, m_off.c, m_off.d, m_off.e, m_off.f),
+            (m_on.a, m_on.b, m_on.c, m_on.d, m_on.e, m_on.f)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_auto_apply_intrinsic_rotation_composes_for_each_rotate_value() -> Result<(), PdfiumError>
+    {
+        // For each /Rotate ∈ {90, 180, 270}, set the page's rotation
+        // and assert apply_to_page emits the expected pre-composed
+        // matrix. This is the bug-pinning anchor for the rotation
+        // matrix derivation.
+        //
+        // The user matrix is identity so apply_to_page emits exactly
+        // `R` (the intrinsic rotation matrix) — easy to read off.
+        let pdfium = test_bind_to_pdfium();
+        let mut document = pdfium.create_new_pdf()?;
+        let mut page = document
+            .pages_mut()
+            .create_page_at_start(PdfPagePaperSize::Portrait(PdfPagePaperStandardSize::A4))?;
+
+        // Pre-rotation A4 dims in pt.
+        let pre_w = page.width().value;
+        let pre_h = page.height().value;
+
+        let cases = [
+            // (rotation, expected R = [a, b, c, d, e, f])
+            (
+                PdfPageRenderRotation::Degrees90,
+                [0.0, -1.0, 1.0, 0.0, 0.0, pre_w],
+            ),
+            (
+                PdfPageRenderRotation::Degrees180,
+                [-1.0, 0.0, 0.0, -1.0, pre_w, pre_h],
+            ),
+            (
+                PdfPageRenderRotation::Degrees270,
+                [0.0, 1.0, -1.0, 0.0, pre_h, 0.0],
+            ),
+        ];
+
+        for (rotation, expected) in cases {
+            page.set_rotation(rotation);
+            assert_eq!(page.rotation()?, rotation);
+
+            let m = matrix_path_config_with(PdfMatrix::IDENTITY)
+                .set_auto_apply_intrinsic_rotation(true)
+                .apply_to_page(&page)
+                .matrix;
+
+            let actual = [m.a, m.b, m.c, m.d, m.e, m.f];
+            for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+                assert!(
+                    (a - e).abs() < 1e-3,
+                    "/Rotate {:?}: matrix component {} diverged: {} vs expected {}",
+                    rotation,
+                    i,
+                    a,
+                    e,
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_auto_apply_intrinsic_rotation_composes_user_matrix_after_rotation(
+    ) -> Result<(), PdfiumError> {
+        // User matrix ∘ R ordering: R applied first (pre-rotation -> display),
+        // user matrix applied second (display -> bitmap). For /Rotate 90 the
+        // libviprs strip-matrix derivation gives, with user = display->pixel
+        // [s, 0, 0, -s, 0, s·display_h_pt - y_off]:
+        //   composed = [0, s, s, 0, 0, -y_off]
+        // We pin one such composition here.
+        let pdfium = test_bind_to_pdfium();
+        let mut document = pdfium.create_new_pdf()?;
+        let mut page = document
+            .pages_mut()
+            .create_page_at_start(PdfPagePaperSize::Portrait(PdfPagePaperStandardSize::A4))?;
+        page.set_rotation(PdfPageRenderRotation::Degrees90);
+
+        // Pre-rotation height is the configured PdfPage height (we set
+        // /Rotate 90 *after* page creation, so width()/height() now
+        // return display-oriented = swapped dims). Pre-rotation w == display h.
+        // Pre-rotation A4: 595 × 842 pt. Display under /Rotate 90: 842 × 595.
+        let display_h_pt = page.height().value; // 595
+        let s: f32 = 2.0;
+        let y_off: f32 = 100.0;
+
+        // user matrix: display-oriented (y-up) -> bitmap pixel (y-down) with strip offset.
+        let user = PdfMatrix::new(s, 0.0, 0.0, -s, 0.0, s * display_h_pt - y_off);
+
+        let m = matrix_path_config_with(user)
+            .set_auto_apply_intrinsic_rotation(true)
+            .apply_to_page(&page)
+            .matrix;
+
+        // Expected per libviprs derivation: [0, s, s, 0, 0, -y_off].
+        let expected = [0.0, s, s, 0.0, 0.0, -y_off];
+        let actual = [m.a, m.b, m.c, m.d, m.e, m.f];
+        for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (a - e).abs() < 1e-3,
+                "matrix component {} diverged: {} vs expected {}",
+                i,
+                a,
+                e,
+            );
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
Closes #253 

Draft. Filing alongside the matching design issue #253 . I'm sketching the intent first so we can hash out the API on the issue thread, then I'll mark this ready for review.

## Summary

I'm adding one new builder method on `PdfRenderConfig`:

```text
pub fn set_auto_apply_intrinsic_rotation(self, yes: bool) -> Self
```

When set, `apply_to_page`'s matrix-path branch fetches `page.rotation()` and pre-rotation page dimensions, builds the rotation matrix `R` mapping pre-rotation page coordinates to display-oriented coordinates, and pre-composes `R.multiply(self.transformation_matrix)` before passing the result to `FPDF_RenderPageBitmapWithMatrix`.

Default `false`. Existing callers see no behavioural change.

## Motivation

The form-data render path (`FPDF_RenderPageBitmap`) auto-applies `/Rotate`. The matrix render path (`FPDF_RenderPageBitmapWithMatrix`) doesn't. Every downstream that wants tiled / strip rendering on a rotated PDF has to derive four separate matrices manually, one per `/Rotate ∈ {0, 90, 180, 270}`, and bake the rotation into the user transform.

I shipped that in libviprs's `PdfiumStripSource` for libviprs#71. It works, but a prior attempt produced 180°-off output on `/Rotate 90/270`, and any other crate doing memory-bounded windowed rendering on rotated PDFs hits the same algebra. Belongs once, in one place, behind a flag.

The four `R` values:

| `/Rotate` | `[a, b, c, d, e, f]`            |
|-----------|---------------------------------|
| 0         | `[1, 0, 0, 1, 0, 0]`            |
| 90        | `[0, -1, 1, 0, 0, w_pre]`       |
| 180       | `[-1, 0, 0, -1, w_pre, h_pre]`  |
| 270       | `[0, 1, -1, 0, h_pre, 0]`       |

`w_pre` / `h_pre` are pre-rotation page dimensions in PDF points (recovered by swapping `page.width()`/`page.height()` when `/Rotate` is 90 or 270, since those getters return display-oriented dims).

## Why this approach (and not the others)

- I'm not adding a `render_*` method or any new entry point. `PdfRenderConfig` already owns matrix configuration; the flag belongs there alongside `apply_matrix`, `clip`, etc.
- I'm not changing the meaning of `apply_matrix` when the flag is off. Every existing matrix-path user supplies a matrix in pre-rotation coords, and changing that under their feet would silently flip output for every rotated PDF in the wild.
- I'm not bumping `pub(crate)` to `pub` on any existing item. The rotation matrix derivation is a private free fn in `render_config.rs`.
- I'm not duplicating #249's `set_origin`. They're complementary: #249 is for the form-data path (so callers who need form rendering can do windowed rendering); this is for the matrix path (so callers who don't need forms can skip the form-data overhead and still get auto-rotation). Different paths, different gaps.

## Relationship to #249 / #251

#249 (`set_origin`) ships windowed rendering on the form-data path. This ships auto-rotation on the matrix path. They cover disjoint use cases. Most callers want one or the other, not both. Issue #251 walks through the form-data side; the issue I'm filing alongside this PR walks through the matrix side.

## Implementation

One commit, one file:

- New field `auto_apply_intrinsic_rotation: bool` on `PdfRenderConfig`.
- New builder method `set_auto_apply_intrinsic_rotation(yes: bool) -> Self`.
- New private free fn `intrinsic_rotation_matrix(rotation, pre_w, pre_h) -> PdfMatrix`.
- One `if self.auto_apply_intrinsic_rotation { ... }` branch at the top of `apply_to_page`'s matrix-path block.
- Four new tests in the existing test module.

No FFI surface changes. No public API breakage.

## Tests

- `test_auto_apply_intrinsic_rotation_default_false`: pins the default.
- `test_auto_apply_intrinsic_rotation_on_zero_rotate_page_is_identity`: composing identity changes nothing on a `/Rotate 0` page.
- `test_auto_apply_intrinsic_rotation_composes_for_each_rotate_value`: for each of `/Rotate {90, 180, 270}` with an identity user matrix, the emitted matrix equals the expected `R`. Pins the four-row derivation table above.
- `test_auto_apply_intrinsic_rotation_composes_user_matrix_after_rotation`: user × R composition order. A display-oriented user matrix on a `/Rotate 90` page must produce the libviprs strip-matrix derivation output. This is the bug-pinning anchor. It fails if the composition order or the pre-rotation dim swap is wrong.

Render-level integration coverage (matrix-path-with-auto-rotate ≡ form-data-path baseline) lives downstream in libviprs-tests's `pdfium_streaming_rotation_matrix.rs` cross-product test.

## Out of scope

- Form-data path windowed rendering (handled by #249).
- Any new render methods or entry points.
- Visibility bumps on existing items.
- `/Rotate` values outside `{0, 90, 180, 270}`: pdfium and the PDF spec restrict it to those, and the existing `PdfPageRenderRotation` enum doesn't represent anything else.
