### PR TITLE
fixes: overflow bug in PdfBitmap::bytes_required_for_size_and_format, and typo in error description

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -235,7 +235,7 @@ pub enum PdfiumError {
     /// When constructing a [crate::pdf::bitmap::PdfBitmap] from a raw buffer, the buffer
     /// must be large enough to contain the bitmap's pixels.
     ///
-    /// This method which returns this error is not available on WASM.
+    /// The method which returns this error is not available on WASM.
     ImageBufferTooSmall,
 
     /// An I/O error occurred during a Pdfium file operation.

--- a/src/pdf/bitmap.rs
+++ b/src/pdf/bitmap.rs
@@ -408,7 +408,9 @@ impl<'a> PdfBitmap<'a> {
         height: Pixels,
         format: PdfBitmapFormat,
     ) -> usize {
-        Self::preferred_stride_bytes(width, format).unwrap_or(4) as usize * height as usize
+        Self::preferred_stride_bytes(width, format)
+            .map(|s| s as usize * height as usize)
+            .unwrap_or_else(|| Self::bytes_required_for_size(width, height))
     }
 
     /// Returns the preferred stride for a [PdfBitmap] of the given width and format.
@@ -655,6 +657,29 @@ mod tests {
         assert_eq!(
             PdfBitmap::preferred_stride_bytes(1 << 30, PdfBitmapFormat::BGRA),
             None
+        );
+    }
+
+    #[test]
+    fn test_bytes_required_for_size_and_format() {
+        // simple case: stride * height
+        assert_eq!(
+            PdfBitmap::bytes_required_for_size_and_format(1, 100, PdfBitmapFormat::Gray),
+            400
+        );
+        assert_eq!(
+            PdfBitmap::bytes_required_for_size_and_format(4, 100, PdfBitmapFormat::Gray),
+            400
+        );
+        assert_eq!(
+            PdfBitmap::bytes_required_for_size_and_format(256, 256, PdfBitmapFormat::BGR),
+            256 * 256 * 3
+        );
+
+        // if stride estimation fails, fall back to 4 bytes per pixel
+        assert_eq!(
+            PdfBitmap::bytes_required_for_size_and_format(1 << 30, 50, PdfBitmapFormat::BGRA),
+            (1 << 30 as usize) * 50 * 4,
         );
     }
 }


### PR DESCRIPTION
Thanks for landing !255 - glad it met with your approval!

Reading back over the code, I realised that I left a minor bug and a typo in the final PR. This PR corrects each of them, and adds tests for the bug. Apologies for the faff!