### PR TITLE
Fix build on platforms where c_char is unsigned (ARM/aarch64 Linux)

### DIFF
--- a/src/pdf/font/provider.rs
+++ b/src/pdf/font/provider.rs
@@ -272,7 +272,7 @@ unsafe extern "C" fn fpdf_sys_font_info_get_face_name(
             let chars = face_name.as_bytes_with_nul();
 
             if !buffer.is_null() && buf_size as usize >= chars.len() {
-                buffer.copy_from_nonoverlapping(chars.as_ptr() as *const i8, chars.len());
+                buffer.copy_from_nonoverlapping(chars.as_ptr() as *const c_char, chars.len());
             }
 
             chars.len() as c_ulong


### PR DESCRIPTION
## Problem

`pdfium-render` fails to compile on targets where `c_char` is **unsigned** — notably `aarch64-unknown-linux-gnu` (and ARM, PowerPC, RISC-V, s390x Linux). The build is fine on x86_64/macOS/Windows, which is likely why it hasn't been noticed.

In `fpdf_sys_font_info_get_face_name` (`src/pdf/font/provider.rs:275`), the source pointer passed to `copy_from_nonoverlapping` is hardcoded to `*const i8`:

```rust
buffer.copy_from_nonoverlapping(chars.as_ptr() as *const i8, chars.len());
```

`buffer` is `*mut c_char`, so `copy_from_nonoverlapping` requires `*const c_char`. `c_char` is `i8` only where it is signed; on ARM/aarch64 Linux it is `u8`, so `buffer` is `*mut u8` and the `*const i8` cast mismatches:

```
error[E0308]: mismatched types
   --> src/pdf/font/provider.rs:275:49
    |
275 |   buffer.copy_from_nonoverlapping(chars.as_ptr() as *const i8, chars.len());
    |          ------------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*const u8`, found `*const i8`
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`
```

This reproduces on current `master` (default features) and on the released `0.9.2` with `pdfium_7763`.

## Fix

Cast to the portable `*const c_char` (already imported in this file) instead of hardcoding `i8`, so the source pointer matches `buffer`'s pointee on every target.

## How to reproduce

On an aarch64-linux host, or cross-target from x86_64 (typeck-only, no pdfium binary or linker needed):

```bash
cargo new repro && cd repro
echo 'pdfium-render = "=0.9.2"' >> Cargo.toml   # or a git dep on master
rustup target add aarch64-unknown-linux-gnu
cargo check --target aarch64-unknown-linux-gnu
```

## Verification

- `cargo check` on `aarch64-unknown-linux-gnu` (rustc 1.94.0): **fails** before this change at `provider.rs:275`, **passes** after.
- The sibling `copy_from_nonoverlapping` at line 246 already copies a `&[u8]` with no cast, so it is unaffected.

Note: nothing else in this PR — I left the README "Release history" entry to you. Happy to adjust the commit/message to your preference.
