### PR TITLE
Copy bytes into JS-owned buffer when filling Pdfium's WASM heap

### DIFF
--- a/src/bindings/wasm_bindings.rs
+++ b/src/bindings/wasm_bindings.rs
@@ -506,8 +506,9 @@ impl PdfiumRenderWasmState {
             "pdfium-render::PdfiumRenderWasmState::copy_bytes_to_pdfium_address(): entering"
         );
 
-        self.heap_u8()
-            .set(unsafe { &Uint8Array::view(bytes) }, remote_ptr as u32);
+        let source = Uint8Array::new_with_length(bytes.len() as u32);
+        source.copy_from(bytes);
+        self.heap_u8().set(&source, remote_ptr as u32);
 
         log::debug!(
             "pdfium-render::PdfiumRenderWasmState::copy_bytes_to_pdfium_address(): copied {} bytes into WASM heap at address {}",


### PR DESCRIPTION
Uint8Array::view hands the pdfium module a live view over our wasm linear memory. 
When Pdfium grows shared memory mid-call (e.g. embedding a TrueType font while filling a large form) the view's ArrayBuffer detaches and the following set() throws 'set on a detached ArrayBuffer'.

Copy the source bytes into a JS-owned Uint8Array first so the buffer survives a memory grow. .