### PR TITLE
Fix two heap corruptions: use-after-free on document close, double-free on page object drop

### DIFF
--- a/src/pdf/document.rs
+++ b/src/pdf/document.rs
@@ -419,6 +419,13 @@ impl<'a> Drop for PdfDocument<'a> {
         // avoiding a segmentation fault when using Pdfium builds compiled with V8/XFA support.
 
         self.form = None;
+
+        // Close all fonts loaded into this document's font registry _before_ closing the
+        // document itself. Struct fields are dropped only _after_ this Drop impl runs, so
+        // without this, each font's FPDFFont_Close() would execute against an already-closed
+        // document, reading freed memory inside Pdfium and corrupting the process heap.
+        self.fonts.clear();
+
         unsafe {
             self.bindings().FPDF_CloseDocument(self.handle);
         }

--- a/src/pdf/document/fonts.rs
+++ b/src/pdf/document/fonts.rs
@@ -573,6 +573,16 @@ impl<'a> PdfFonts<'a> {
     pub fn get(&self, token: PdfFontToken) -> Option<&PdfFont<'_>> {
         self.fonts.get(&token)
     }
+
+    /// Drops every font in this registry, releasing each font's `FPDF_FONT` handle.
+    ///
+    /// This MUST be called before `FPDF_CloseDocument()`: calling `FPDFFont_Close()`
+    /// on a font whose owning document has already been closed reads freed memory
+    /// inside Pdfium, corrupting the heap. See `PdfDocument::drop()`.
+    #[inline]
+    pub(crate) fn clear(&mut self) {
+        self.fonts.clear();
+    }
 }
 
 impl<'a> PdfiumLibraryBindingsAccessor<'a> for PdfFonts<'a> {}

--- a/src/pdf/document/page/object.rs
+++ b/src/pdf/document/page/object.rs
@@ -1293,21 +1293,12 @@ impl<'a> Drop for PdfPageObject<'a> {
     /// Closes this [PdfPageObject], releasing held memory.
     #[inline]
     fn drop(&mut self) {
-        // The documentation for FPDFPageObj_Destroy() states that we only need
-        // call the function for page objects created by FPDFPageObj_CreateNew*() or
-        // FPDFPageObj_New*Obj() _and_ where the newly-created object was _not_ subsequently
-        // added to a PdfPage or PdfPageAnnotation via a call to FPDFPage_InsertObject() or
-        // FPDFAnnot_AppendObject().
-
-        // In other words, retrieving a page object that already exists in a document evidently
-        // does not allocate any additional resources, so we don't need to free anything.
-        // (Indeed, if we try to, Pdfium segfaults.)
-
-        if !self.ownership().is_owned() {
-            unsafe {
-                self.bindings().FPDFPageObj_Destroy(self.object_handle());
-            }
-        }
+        // Deliberately empty: every enum variant wraps a concrete page object type
+        // (PdfPageTextObject, PdfPagePathObject, ...) and each of those types already
+        // calls FPDFPageObj_Destroy() in its own Drop impl (via drop_impl()) when the
+        // object is unowned. Calling FPDFPageObj_Destroy() here as well destroyed the
+        // same handle twice - a double-free that corrupted Pdfium's heap whenever an
+        // unowned object (e.g. one returned by FPDFPage_RemoveObject) was dropped.
     }
 }
 


### PR DESCRIPTION
This PR fixes two memory-safety bugs that manifest as random `STATUS_ACCESS_VIOLATION` crashes (heap corruption) in long-running applications that load fonts and add/remove page objects. Both were found while building a PDF editor on top of pdfium-render 0.9.2 and are still present in the current sources.

## Bug 1: use-after-free when closing a document with loaded fonts

`PdfDocument::drop()` calls `FPDF_CloseDocument()` directly, while the document's `fonts` registry (which owns `FPDF_FONT` handles) is a struct field. Struct fields are dropped *after* the `Drop` impl body runs, so every `PdfFont::drop()` ends up calling `FPDFFont_Close()` against a document that has already been closed. Inside Pdfium this reads freed memory and corrupts the allocator heap; the crash surfaces later at an unrelated allocation, which makes it very hard to attribute (we confirmed the read-after-free with AddressSanitizer on Windows).

Fix: drop all fonts in the registry *before* `FPDF_CloseDocument()`, the same way `self.form = None` is already handled in `PdfDocument::drop()`. A `pub(crate) fn clear()` is added to the fonts registry for this.

## Bug 2: double-free when dropping an unowned `PdfPageObject`

The `PdfPageObject` enum wrapper had its own `Drop` impl calling `FPDFPageObj_Destroy()`, but every enum variant wraps a concrete object type (`PdfPageTextObject`, `PdfPagePathObject`, ...) whose own `Drop` also calls `FPDFPageObj_Destroy()` for unowned objects. Dropping an unowned object - for example the value returned by `PdfPageObjects::remove_object_at_index()` - destroyed the same `FPDF_PAGEOBJECT` handle twice, corrupting Pdfium's heap.

Fix: make the wrapper's `Drop` a no-op and leave destruction to the concrete object types, which already track ownership correctly.

## How we hit this

Editor workflow: replace a text object (create new + remove old), close the document, open the next one. With both bugs present the process crashed with `STATUS_ACCESS_VIOLATION` after a few dozen iterations; with these fixes the same suite has been running clean for weeks (including under AddressSanitizer, `-Zsanitizer=address` on nightly / MSVC).

## Testing

- `cargo build` and `cargo test` pass with no regressions
- Verified with AddressSanitizer on a minimal reproduction for each bug:
  - Load font → close document (use-after-free fixed)
  - Remove page object → drop result (double-free fixed)
- Both bugs were reproducible in isolation and no longer occur after this fix

## Affected versions

This affects all versions up to current master (including 0.9.2 and 0.10.x). The fix is backward-compatible and does not change public API.

## Files changed

- `src/pdf/document.rs` - added `self.fonts.clear()` before `FPDF_CloseDocument()`
- `src/pdf/document/fonts.rs` - added `clear()` method to `PdfFonts`
- `src/pdf/document/page/object.rs` - removed `Drop` impl from `PdfPageObject` wrapper