### PR TITLE
Scope page index cache test assertions per document

### DIFF
--- a/src/pdf/document/page/index_cache.rs
+++ b/src/pdf/document/page/index_cache.rs
@@ -244,6 +244,47 @@ impl PdfPageIndexCache {
         Self::lock().get(document, page).map(|props| props.index)
     }
 
+    /// Returns the number of `pages_by_index` entries currently cached for the given raw document
+    /// handle. The [PAGE_INDEX_CACHE] is process-global and shared by every open document, so
+    /// counting entries scoped to a single document is the only way a test can assert on cache
+    /// contents without depending on what other, concurrently running tests happen to have cached.
+    ///
+    /// This is a guard-free accessor: it acquires the lock internally and returns a plain `usize`,
+    /// so a caller never holds a [MutexGuard] across an assertion made on the result. A failing
+    /// assertion therefore cannot poison [PAGE_INDEX_CACHE] while a guard is still live.
+    #[cfg(test)]
+    #[inline]
+    fn count_for_document(document: FPDF_DOCUMENT) -> usize {
+        Self::lock()
+            .pages_by_index
+            .keys()
+            .filter(|(cached_document, _)| *cached_document == document)
+            .count()
+    }
+
+    /// Returns the currently cached maximum [PdfPageIndex] for the given raw document handle, if
+    /// any. Guard-free accessor; see [PdfPageIndexCache::count_for_document].
+    #[cfg(test)]
+    #[inline]
+    fn maximum_index_for_document(document: FPDF_DOCUMENT) -> Option<PdfPageIndex> {
+        Self::lock()
+            .documents_by_maximum_index
+            .get(&document)
+            .copied()
+    }
+
+    /// Returns the raw page handle cached in the reverse (`indices_by_page`) map for the given raw
+    /// document handle and [PdfPageIndex], if any. Guard-free accessor; see
+    /// [PdfPageIndexCache::count_for_document].
+    #[cfg(test)]
+    #[inline]
+    fn page_for_index(document: FPDF_DOCUMENT, index: PdfPageIndex) -> Option<FPDF_PAGE> {
+        Self::lock()
+            .indices_by_page
+            .get(&(document, index))
+            .copied()
+    }
+
     /// Returns the current [PdfPageContentRegenerationStrategy] value for the given raw document
     /// and page handles, if any.
     #[inline]
@@ -301,7 +342,7 @@ mod tests {
 
         let mut document = pdfium.create_new_pdf()?;
 
-        assert!(PdfPageIndexCache::lock().pages_by_index.is_empty());
+        assert_eq!(PdfPageIndexCache::count_for_document(document.handle()), 0);
 
         {
             // Now let's create a blank page and get a handle to it...
@@ -312,12 +353,12 @@ mod tests {
 
             // ... and confirm the cache updated.
 
-            assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 1);
+            assert_eq!(PdfPageIndexCache::count_for_document(document.handle()), 1);
         }
 
         // The page has dropped out of scope. Confirm the cache got cleaned up.
 
-        assert!(PdfPageIndexCache::lock().pages_by_index.is_empty());
+        assert_eq!(PdfPageIndexCache::count_for_document(document.handle()), 0);
 
         // Get a new handle to the page...
 
@@ -325,7 +366,7 @@ mod tests {
 
         // ... and confirm the cache updated.
 
-        assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 1);
+        assert_eq!(PdfPageIndexCache::count_for_document(document.handle()), 1);
 
         Ok(())
     }
@@ -346,69 +387,83 @@ mod tests {
             }
 
             // Since we haven't retrieved any references to these pages, the index cache
-            // should be empty.
+            // should hold no entries for this document.
 
-            assert!(PdfPageIndexCache::lock().pages_by_index.is_empty());
+            assert_eq!(
+                PdfPageIndexCache::count_for_document(document_0.handle()),
+                0
+            );
 
             // Check that the cache gets populated as we retrieve references to pages.
 
             let document_0_page_0 = document_0.pages().get(0)?;
 
-            assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 1);
+            assert_eq!(
+                PdfPageIndexCache::count_for_document(document_0.handle()),
+                1
+            );
 
             let document_0_page_1 = document_0.pages().get(1)?;
 
-            assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 2);
+            assert_eq!(
+                PdfPageIndexCache::count_for_document(document_0.handle()),
+                2
+            );
 
             let document_0_page_2 = document_0.pages().get(2)?;
 
-            assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 3);
+            assert_eq!(
+                PdfPageIndexCache::count_for_document(document_0.handle()),
+                3
+            );
 
             // Check the cached indices are correct.
 
-            assert!(PdfPageIndexCache::lock()
-                .get(document_0.handle(), document_0_page_0.page_handle())
-                .is_some());
+            assert!(PdfPageIndexCache::get_index_for_page(
+                document_0.handle(),
+                document_0_page_0.page_handle()
+            )
+            .is_some());
             assert!(
-                PdfPageIndexCache::lock()
-                    .get(document_0.handle(), document_0_page_0.page_handle())
-                    .unwrap()
-                    .index
+                PdfPageIndexCache::get_index_for_page(
+                    document_0.handle(),
+                    document_0_page_0.page_handle()
+                )
+                .unwrap()
                     == 0
             );
 
-            assert!(PdfPageIndexCache::lock()
-                .get(document_0.handle(), document_0_page_1.page_handle())
-                .is_some());
+            assert!(PdfPageIndexCache::get_index_for_page(
+                document_0.handle(),
+                document_0_page_1.page_handle()
+            )
+            .is_some());
             assert!(
-                PdfPageIndexCache::lock()
-                    .get(document_0.handle(), document_0_page_1.page_handle())
-                    .unwrap()
-                    .index
+                PdfPageIndexCache::get_index_for_page(
+                    document_0.handle(),
+                    document_0_page_1.page_handle()
+                )
+                .unwrap()
                     == 1
             );
 
-            assert!(PdfPageIndexCache::lock()
-                .get(document_0.handle(), document_0_page_2.page_handle())
-                .is_some());
+            assert!(PdfPageIndexCache::get_index_for_page(
+                document_0.handle(),
+                document_0_page_2.page_handle()
+            )
+            .is_some());
             assert!(
-                PdfPageIndexCache::lock()
-                    .get(document_0.handle(), document_0_page_2.page_handle())
-                    .unwrap()
-                    .index
+                PdfPageIndexCache::get_index_for_page(
+                    document_0.handle(),
+                    document_0_page_2.page_handle()
+                )
+                .unwrap()
                     == 2
             );
 
-            assert!(PdfPageIndexCache::lock()
-                .documents_by_maximum_index
-                .get(&document_0.handle())
-                .is_some());
+            assert!(PdfPageIndexCache::maximum_index_for_document(document_0.handle()).is_some());
             assert_eq!(
-                PdfPageIndexCache::lock()
-                    .documents_by_maximum_index
-                    .get(&document_0.handle())
-                    .copied()
-                    .unwrap(),
+                PdfPageIndexCache::maximum_index_for_document(document_0.handle()).unwrap(),
                 2
             );
 
@@ -426,85 +481,112 @@ mod tests {
                         .create_page_at_end(PdfPagePaperSize::a4())?;
                 }
 
-                // Since we haven't retrieved any references to these pages, the index cache
-                // should only contain the references to the pages from the first document.
+                // Since we haven't retrieved any references to these pages, the second document
+                // should not yet contribute any entries to the cache, while the first document's
+                // three entries remain untouched.
 
-                assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 3);
+                assert_eq!(
+                    PdfPageIndexCache::count_for_document(document_0.handle()),
+                    3
+                );
+                assert_eq!(
+                    PdfPageIndexCache::count_for_document(document_1.handle()),
+                    0
+                );
 
                 // Check that the cache gets populated as we retrieve references to pages.
 
                 let document_1_page_0 = document_1.pages().get(0)?;
 
-                assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 4);
-
-                let document_1_page_1 = document_1.pages().get(1)?;
-
-                assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 5);
-
-                let document_1_page_2 = document_1.pages().get(2)?;
-
-                assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 6);
-
-                let document_1_page_3 = document_1.pages().get(3)?;
-
-                assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 7);
-
-                // Check the cached indices are correct.
-
-                assert!(PdfPageIndexCache::lock()
-                    .get(document_1.handle(), document_1_page_0.page_handle())
-                    .is_some());
                 assert_eq!(
-                    PdfPageIndexCache::lock()
-                        .get(document_1.handle(), document_1_page_0.page_handle())
-                        .unwrap()
-                        .index,
-                    0
-                );
-
-                assert!(PdfPageIndexCache::lock()
-                    .get(document_1.handle(), document_1_page_1.page_handle())
-                    .is_some());
-                assert_eq!(
-                    PdfPageIndexCache::lock()
-                        .get(document_1.handle(), document_1_page_1.page_handle())
-                        .unwrap()
-                        .index,
+                    PdfPageIndexCache::count_for_document(document_1.handle()),
                     1
                 );
 
-                assert!(PdfPageIndexCache::lock()
-                    .get(document_1.handle(), document_1_page_2.page_handle())
-                    .is_some());
+                let document_1_page_1 = document_1.pages().get(1)?;
+
                 assert_eq!(
-                    PdfPageIndexCache::lock()
-                        .get(document_1.handle(), document_1_page_2.page_handle())
-                        .unwrap()
-                        .index,
+                    PdfPageIndexCache::count_for_document(document_1.handle()),
                     2
                 );
 
-                assert!(PdfPageIndexCache::lock()
-                    .get(document_1.handle(), document_1_page_3.page_handle())
-                    .is_some());
+                let document_1_page_2 = document_1.pages().get(2)?;
+
                 assert_eq!(
-                    PdfPageIndexCache::lock()
-                        .get(document_1.handle(), document_1_page_3.page_handle())
-                        .unwrap()
-                        .index,
+                    PdfPageIndexCache::count_for_document(document_1.handle()),
                     3
                 );
 
-                assert!(PdfPageIndexCache::lock()
-                    .documents_by_maximum_index
-                    .get(&document_1.handle())
-                    .is_some());
+                let document_1_page_3 = document_1.pages().get(3)?;
+
                 assert_eq!(
-                    PdfPageIndexCache::lock()
-                        .documents_by_maximum_index
-                        .get(&document_1.handle())
-                        .copied()
-                        .unwrap(),
+                    PdfPageIndexCache::count_for_document(document_1.handle()),
+                    4
+                );
+
+                // Check the cached indices are correct.
+
+                assert!(PdfPageIndexCache::get_index_for_page(
+                    document_1.handle(),
+                    document_1_page_0.page_handle()
+                )
+                .is_some());
+                assert_eq!(
+                    PdfPageIndexCache::get_index_for_page(
+                        document_1.handle(),
+                        document_1_page_0.page_handle()
+                    )
+                    .unwrap(),
+                    0
+                );
+
+                assert!(PdfPageIndexCache::get_index_for_page(
+                    document_1.handle(),
+                    document_1_page_1.page_handle()
+                )
+                .is_some());
+                assert_eq!(
+                    PdfPageIndexCache::get_index_for_page(
+                        document_1.handle(),
+                        document_1_page_1.page_handle()
+                    )
+                    .unwrap(),
+                    1
+                );
+
+                assert!(PdfPageIndexCache::get_index_for_page(
+                    document_1.handle(),
+                    document_1_page_2.page_handle()
+                )
+                .is_some());
+                assert_eq!(
+                    PdfPageIndexCache::get_index_for_page(
+                        document_1.handle(),
+                        document_1_page_2.page_handle()
+                    )
+                    .unwrap(),
+                    2
+                );
+
+                assert!(PdfPageIndexCache::get_index_for_page(
+                    document_1.handle(),
+                    document_1_page_3.page_handle()
+                )
+                .is_some());
+                assert_eq!(
+                    PdfPageIndexCache::get_index_for_page(
+                        document_1.handle(),
+                        document_1_page_3.page_handle()
+                    )
+                    .unwrap(),
+                    3
+                );
+
+                assert!(
+                    PdfPageIndexCache::maximum_index_for_document(document_1.handle()).is_some()
+                );
+                assert_eq!(
+                    PdfPageIndexCache::maximum_index_for_document(document_1.handle()).unwrap(),
                     3
                 );
             }
@@ -512,13 +594,23 @@ mod tests {
             // At this point, the pages from document_1 have been dropped. Those pages should
             // have been removed from the cache.
 
-            assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 3);
+            assert_eq!(
+                PdfPageIndexCache::count_for_document(document_1.handle()),
+                0
+            );
+            assert_eq!(
+                PdfPageIndexCache::count_for_document(document_0.handle()),
+                3
+            );
         }
 
         // At this point, the pages from document_0 have been dropped. Those pages should
-        // have been removed from the cache; the cache should now be empty.
+        // have been removed from the cache; the cache should now hold no entries for it.
 
-        assert!(PdfPageIndexCache::lock().pages_by_index.is_empty());
+        assert_eq!(
+            PdfPageIndexCache::count_for_document(document_0.handle()),
+            0
+        );
 
         Ok(())
     }
@@ -538,14 +630,13 @@ mod tests {
 
             // ... confirm the index of the page is cached...
 
-            assert!(PdfPageIndexCache::lock()
-                .get(document.handle(), page.page_handle())
-                .is_some());
+            assert!(
+                PdfPageIndexCache::get_index_for_page(document.handle(), page.page_handle())
+                    .is_some()
+            );
             assert_eq!(
-                PdfPageIndexCache::lock()
-                    .get(document.handle(), page.page_handle())
-                    .unwrap()
-                    .index,
+                PdfPageIndexCache::get_index_for_page(document.handle(), page.page_handle())
+                    .unwrap(),
                 0
             );
 
@@ -557,9 +648,7 @@ mod tests {
         // At this point, the page itself has been dropped, so the page handle is no longer valid.
         // Attempting to retrieve the cached index for the page should return None.
 
-        assert!(PdfPageIndexCache::lock()
-            .get(document.handle(), page_handle)
-            .is_none());
+        assert!(PdfPageIndexCache::get_index_for_page(document.handle(), page_handle).is_none());
 
         Ok(())
     }
@@ -587,29 +676,25 @@ mod tests {
                 );
             }
 
-            assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 100);
-            assert!(PdfPageIndexCache::lock()
-                .documents_by_maximum_index
-                .get(&document.handle())
-                .is_some());
             assert_eq!(
-                PdfPageIndexCache::lock()
-                    .documents_by_maximum_index
-                    .get(&document.handle())
-                    .copied()
-                    .unwrap(),
+                PdfPageIndexCache::count_for_document(document.handle()),
+                100
+            );
+            assert!(PdfPageIndexCache::maximum_index_for_document(document.handle()).is_some());
+            assert_eq!(
+                PdfPageIndexCache::maximum_index_for_document(document.handle()).unwrap(),
                 99
             );
 
             for (index, page) in pages.iter().enumerate() {
-                assert!(PdfPageIndexCache::lock()
-                    .get(document.handle(), page.page_handle())
-                    .is_some());
+                assert!(PdfPageIndexCache::get_index_for_page(
+                    document.handle(),
+                    page.page_handle()
+                )
+                .is_some());
                 assert_eq!(
-                    PdfPageIndexCache::lock()
-                        .get(document.handle(), page.page_handle())
-                        .unwrap()
-                        .index,
+                    PdfPageIndexCache::get_index_for_page(document.handle(), page.page_handle())
+                        .unwrap(),
                     index as PdfPageIndex
                 );
             }
@@ -620,42 +705,38 @@ mod tests {
                 .pages_mut()
                 .create_page_at_start(PdfPagePaperSize::a4())?;
 
-            assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 101);
-            assert!(PdfPageIndexCache::lock()
-                .documents_by_maximum_index
-                .get(&document.handle())
-                .is_some());
             assert_eq!(
-                PdfPageIndexCache::lock()
-                    .documents_by_maximum_index
-                    .get(&document.handle())
-                    .copied()
-                    .unwrap(),
+                PdfPageIndexCache::count_for_document(document.handle()),
+                101
+            );
+            assert!(PdfPageIndexCache::maximum_index_for_document(document.handle()).is_some());
+            assert_eq!(
+                PdfPageIndexCache::maximum_index_for_document(document.handle()).unwrap(),
                 100
             );
 
-            assert!(PdfPageIndexCache::lock()
-                .get(document.handle(), inserted.page_handle())
-                .is_some());
+            assert!(PdfPageIndexCache::get_index_for_page(
+                document.handle(),
+                inserted.page_handle()
+            )
+            .is_some());
             assert_eq!(
-                PdfPageIndexCache::lock()
-                    .get(document.handle(), inserted.page_handle())
-                    .unwrap()
-                    .index,
+                PdfPageIndexCache::get_index_for_page(document.handle(), inserted.page_handle())
+                    .unwrap(),
                 0
             );
 
             // ... and check that the index positions for all other pages have correctly shuffled down.
 
             for (index, page) in pages.iter().enumerate() {
-                assert!(PdfPageIndexCache::lock()
-                    .get(document.handle(), page.page_handle())
-                    .is_some());
+                assert!(PdfPageIndexCache::get_index_for_page(
+                    document.handle(),
+                    page.page_handle()
+                )
+                .is_some());
                 assert_eq!(
-                    PdfPageIndexCache::lock()
-                        .get(document.handle(), page.page_handle())
-                        .unwrap()
-                        .index,
+                    PdfPageIndexCache::get_index_for_page(document.handle(), page.page_handle())
+                        .unwrap(),
                     index as PdfPageIndex + 1
                 );
             }
@@ -666,28 +747,24 @@ mod tests {
                 .pages_mut()
                 .create_page_at_index(PdfPagePaperSize::a4(), 50)?;
 
-            assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 102);
-            assert!(PdfPageIndexCache::lock()
-                .documents_by_maximum_index
-                .get(&document.handle())
-                .is_some());
             assert_eq!(
-                PdfPageIndexCache::lock()
-                    .documents_by_maximum_index
-                    .get(&document.handle())
-                    .copied()
-                    .unwrap(),
+                PdfPageIndexCache::count_for_document(document.handle()),
+                102
+            );
+            assert!(PdfPageIndexCache::maximum_index_for_document(document.handle()).is_some());
+            assert_eq!(
+                PdfPageIndexCache::maximum_index_for_document(document.handle()).unwrap(),
                 101
             );
 
-            assert!(PdfPageIndexCache::lock()
-                .get(document.handle(), inserted.page_handle())
-                .is_some());
+            assert!(PdfPageIndexCache::get_index_for_page(
+                document.handle(),
+                inserted.page_handle()
+            )
+            .is_some());
             assert_eq!(
-                PdfPageIndexCache::lock()
-                    .get(document.handle(), inserted.page_handle())
-                    .unwrap()
-                    .index,
+                PdfPageIndexCache::get_index_for_page(document.handle(), inserted.page_handle())
+                    .unwrap(),
                 50
             );
 
@@ -700,27 +777,33 @@ mod tests {
                 // 50 is our _second_ insertion into the page sequence.
 
                 if index < 49 {
-                    assert!(PdfPageIndexCache::lock()
-                        .get(document.handle(), page.page_handle())
-                        .is_some());
+                    assert!(PdfPageIndexCache::get_index_for_page(
+                        document.handle(),
+                        page.page_handle()
+                    )
+                    .is_some());
                     assert_eq!(
-                        PdfPageIndexCache::lock()
-                            .get(document.handle(), page.page_handle())
-                            .unwrap()
-                            .index,
+                        PdfPageIndexCache::get_index_for_page(
+                            document.handle(),
+                            page.page_handle()
+                        )
+                        .unwrap(),
                         index as PdfPageIndex + 1
                     );
                 }
 
                 if index > 49 {
-                    assert!(PdfPageIndexCache::lock()
-                        .get(document.handle(), page.page_handle())
-                        .is_some());
+                    assert!(PdfPageIndexCache::get_index_for_page(
+                        document.handle(),
+                        page.page_handle()
+                    )
+                    .is_some());
                     assert_eq!(
-                        PdfPageIndexCache::lock()
-                            .get(document.handle(), page.page_handle())
-                            .unwrap()
-                            .index,
+                        PdfPageIndexCache::get_index_for_page(
+                            document.handle(),
+                            page.page_handle()
+                        )
+                        .unwrap(),
                         index as PdfPageIndex + 2
                     );
                 }
@@ -753,17 +836,13 @@ mod tests {
                 ));
             }
 
-            assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 100);
-            assert!(PdfPageIndexCache::lock()
-                .documents_by_maximum_index
-                .get(&document.handle())
-                .is_some());
             assert_eq!(
-                PdfPageIndexCache::lock()
-                    .documents_by_maximum_index
-                    .get(&document.handle())
-                    .copied()
-                    .unwrap(),
+                PdfPageIndexCache::count_for_document(document.handle()),
+                100
+            );
+            assert!(PdfPageIndexCache::maximum_index_for_document(document.handle()).is_some());
+            assert_eq!(
+                PdfPageIndexCache::maximum_index_for_document(document.handle()).unwrap(),
                 99
             );
 
@@ -773,9 +852,9 @@ mod tests {
                 let document = document.handle();
                 let page = page.as_ref().unwrap().page_handle();
 
-                assert!(PdfPageIndexCache::lock().get(document, page).is_some());
+                assert!(PdfPageIndexCache::get_index_for_page(document, page).is_some());
                 assert_eq!(
-                    PdfPageIndexCache::lock().get(document, page).unwrap().index,
+                    PdfPageIndexCache::get_index_for_page(document, page).unwrap(),
                     index as PdfPageIndex
                 );
             }
@@ -784,17 +863,10 @@ mod tests {
 
             pages.first_mut().unwrap().take().unwrap().delete()?;
 
-            assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 99);
-            assert!(PdfPageIndexCache::lock()
-                .documents_by_maximum_index
-                .get(&document.handle())
-                .is_some());
+            assert_eq!(PdfPageIndexCache::count_for_document(document.handle()), 99);
+            assert!(PdfPageIndexCache::maximum_index_for_document(document.handle()).is_some());
             assert_eq!(
-                PdfPageIndexCache::lock()
-                    .documents_by_maximum_index
-                    .get(&document.handle())
-                    .copied()
-                    .unwrap(),
+                PdfPageIndexCache::maximum_index_for_document(document.handle()).unwrap(),
                 98
             );
 
@@ -811,9 +883,9 @@ mod tests {
                     let document = document.handle();
                     let page = page.as_ref().unwrap().page_handle();
 
-                    assert!(PdfPageIndexCache::lock().get(document, page).is_some());
+                    assert!(PdfPageIndexCache::get_index_for_page(document, page).is_some());
                     assert_eq!(
-                        PdfPageIndexCache::lock().get(document, page).unwrap().index,
+                        PdfPageIndexCache::get_index_for_page(document, page).unwrap(),
                         index as PdfPageIndex - 1
                     );
                 }
@@ -823,17 +895,10 @@ mod tests {
 
             pages.get_mut(50).unwrap().take().unwrap().delete()?;
 
-            assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 98);
-            assert!(PdfPageIndexCache::lock()
-                .documents_by_maximum_index
-                .get(&document.handle())
-                .is_some());
+            assert_eq!(PdfPageIndexCache::count_for_document(document.handle()), 98);
+            assert!(PdfPageIndexCache::maximum_index_for_document(document.handle()).is_some());
             assert_eq!(
-                PdfPageIndexCache::lock()
-                    .documents_by_maximum_index
-                    .get(&document.handle())
-                    .copied()
-                    .unwrap(),
+                PdfPageIndexCache::maximum_index_for_document(document.handle()).unwrap(),
                 97
             );
 
@@ -851,9 +916,9 @@ mod tests {
                     let document = document.handle();
                     let page = page.as_ref().unwrap().page_handle();
 
-                    assert!(PdfPageIndexCache::lock().get(document, page).is_some());
+                    assert!(PdfPageIndexCache::get_index_for_page(document, page).is_some());
                     assert_eq!(
-                        PdfPageIndexCache::lock().get(document, page).unwrap().index,
+                        PdfPageIndexCache::get_index_for_page(document, page).unwrap(),
                         index as PdfPageIndex - 1
                     );
                 } else if index > 50 {
@@ -862,9 +927,9 @@ mod tests {
                     let document = document.handle();
                     let page = page.as_ref().unwrap().page_handle();
 
-                    assert!(PdfPageIndexCache::lock().get(document, page).is_some());
+                    assert!(PdfPageIndexCache::get_index_for_page(document, page).is_some());
                     assert_eq!(
-                        PdfPageIndexCache::lock().get(document, page).unwrap().index,
+                        PdfPageIndexCache::get_index_for_page(document, page).unwrap(),
                         index as PdfPageIndex - 2
                     );
                 }
@@ -899,29 +964,25 @@ mod tests {
                 );
             }
 
-            assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 100);
-            assert!(PdfPageIndexCache::lock()
-                .documents_by_maximum_index
-                .get(&document.handle())
-                .is_some());
             assert_eq!(
-                PdfPageIndexCache::lock()
-                    .documents_by_maximum_index
-                    .get(&document.handle())
-                    .copied()
-                    .unwrap(),
+                PdfPageIndexCache::count_for_document(document.handle()),
+                100
+            );
+            assert!(PdfPageIndexCache::maximum_index_for_document(document.handle()).is_some());
+            assert_eq!(
+                PdfPageIndexCache::maximum_index_for_document(document.handle()).unwrap(),
                 99
             );
 
             for (index, page) in pages.iter().enumerate() {
-                assert!(PdfPageIndexCache::lock()
-                    .get(document.handle(), page.page_handle())
-                    .is_some());
+                assert!(PdfPageIndexCache::get_index_for_page(
+                    document.handle(),
+                    page.page_handle()
+                )
+                .is_some());
                 assert_eq!(
-                    PdfPageIndexCache::lock()
-                        .get(document.handle(), page.page_handle())
-                        .unwrap()
-                        .index,
+                    PdfPageIndexCache::get_index_for_page(document.handle(), page.page_handle())
+                        .unwrap(),
                     index as PdfPageIndex
                 );
             }
@@ -929,32 +990,20 @@ mod tests {
             // Our cache now holds 100 index positions. Delete all 100 pages.
 
             for index in (0..100).rev() {
-                assert!(PdfPageIndexCache::lock()
-                    .documents_by_maximum_index
-                    .get(&document.handle())
-                    .is_some());
+                assert!(PdfPageIndexCache::maximum_index_for_document(document.handle()).is_some());
                 assert_eq!(
-                    PdfPageIndexCache::lock()
-                        .documents_by_maximum_index
-                        .get(&document.handle())
-                        .copied()
-                        .unwrap(),
+                    PdfPageIndexCache::maximum_index_for_document(document.handle()).unwrap(),
                     index
                 );
 
-                PdfPageIndexCache::lock().delete(document.handle(), index, 1);
+                PdfPageIndexCache::delete_pages_at_index(document.handle(), index, 1);
 
                 if index > 0 {
-                    assert!(PdfPageIndexCache::lock()
-                        .documents_by_maximum_index
-                        .get(&document.handle())
-                        .is_some());
+                    assert!(
+                        PdfPageIndexCache::maximum_index_for_document(document.handle()).is_some()
+                    );
                     assert_eq!(
-                        PdfPageIndexCache::lock()
-                            .documents_by_maximum_index
-                            .get(&document.handle())
-                            .copied()
-                            .unwrap(),
+                        PdfPageIndexCache::maximum_index_for_document(document.handle()).unwrap(),
                         index - 1
                     );
                 }
@@ -962,45 +1011,130 @@ mod tests {
 
             // All pages are now deleted.
 
-            assert!(PdfPageIndexCache::lock().pages_by_index.is_empty());
-            assert!(PdfPageIndexCache::lock()
-                .documents_by_maximum_index
-                .get(&document.handle())
-                .is_none());
+            assert_eq!(PdfPageIndexCache::count_for_document(document.handle()), 0);
+            assert!(PdfPageIndexCache::maximum_index_for_document(document.handle()).is_none());
         }
 
         Ok(())
     }
 
     #[test]
-    fn global_cache_assertions_are_not_isolated_across_documents() -> Result<(), PdfiumError> {
-        // This test encodes the buggy global assumption that the existing cache tests rely on:
-        // that the process-global PAGE_INDEX_CACHE holds entries only for the document currently
-        // under test. I set up two live documents at once so that assumption is provably false,
-        // then run the exact global-style length assertion the existing suite uses.
+    fn count_for_document_isolates_entries_by_document_handle() {
+        // Pure-logic pin for the fix. It exercises the shared PAGE_INDEX_CACHE directly with
+        // synthetic (non-pdfium) document and page handles, so it needs no native library and runs
+        // deterministically from a single thread.
         //
-        // It is RED on this commit because document A's entries are still present when I assert
-        // that only document B's entries exist. That is the isolation flaw: any test that asserts
-        // on `pages_by_index.len()` or `pages_by_index.is_empty()` is really asserting on state
-        // owned by every other test that happens to be touching the shared cache. Under the
-        // default multi-threaded `cargo test`, a concurrent test supplies that foreign state and
-        // the assertion fails; here I supply it deterministically from a single thread.
+        // It reproduces the isolation flaw described in the issue: once two different documents have
+        // entries in the shared cache at the same time, a global `pages_by_index.len()` assertion
+        // sees BOTH documents' entries, while a document-scoped `count_for_document` sees only the
+        // entries it owns. Before the fix, the suite asserted on the global length and therefore
+        // failed whenever a second document was present (which, under the default multi-threaded
+        // `cargo test`, a concurrent test routinely supplies). After the fix, the assertions are
+        // document-scoped and hold no matter what else is in the cache.
         //
-        // This should turn GREEN once the assertions become document-scoped (counting only the
-        // entries whose document handle matches the document under test), as proposed in the
-        // linked issue.
-        //
-        // I deliberately read the cache length into a local BEFORE asserting, so the temporary
-        // MutexGuard from lock() is released before assert_eq! can panic. That keeps the failure
-        // a clean unwinding assertion the harness reports as FAIL. If I asserted while still
-        // holding the guard, the panic would poison the mutex and the subsequent page drops would
-        // re-panic inside their destructors, aborting the whole test binary (signal 6), which is
-        // exactly the real-world symptom described in the issue.
+        // Large, distinctive synthetic handle values keep this test's own entries easy to identify
+        // and remove. The assertions below only ever reason about the two synthetic documents this
+        // test owns; they make no claim about foreign entries left by other tests.
+
+        use crate::bindgen::{FPDF_DOCUMENT, FPDF_PAGE};
+        use crate::pdf::document::page::PdfPageContentRegenerationStrategy;
+
+        let document_a = 0xA000_0000usize as FPDF_DOCUMENT;
+        let document_b = 0xB000_0000usize as FPDF_DOCUMENT;
+
+        let a_page_0 = 0xA000_0001usize as FPDF_PAGE;
+        let a_page_1 = 0xA000_0002usize as FPDF_PAGE;
+        let b_page_0 = 0xB000_0001usize as FPDF_PAGE;
+        let b_page_1 = 0xB000_0002usize as FPDF_PAGE;
+        let b_page_2 = 0xB000_0003usize as FPDF_PAGE;
+
+        // Document A contributes two entries; document B contributes three. They coexist in the
+        // shared cache, exactly the situation that breaks a global-length assertion.
+
+        for (page, index) in [(a_page_0, 0), (a_page_1, 1)] {
+            PdfPageIndexCache::cache_props_for_page(
+                document_a,
+                page,
+                index,
+                PdfPageContentRegenerationStrategy::AutomaticOnEveryChange,
+            );
+        }
+
+        for (page, index) in [(b_page_0, 0), (b_page_1, 1), (b_page_2, 2)] {
+            PdfPageIndexCache::cache_props_for_page(
+                document_b,
+                page,
+                index,
+                PdfPageContentRegenerationStrategy::AutomaticOnEveryChange,
+            );
+        }
+
+        // The document-scoped counts are exact and isolated: each document sees only its own
+        // entries, regardless of the other document or of any foreign entries left in the shared
+        // cache by concurrent tests. These accessors are guard-free, so a failing assertion here
+        // holds no cache mutex guard across its panic.
+
+        assert_eq!(
+            PdfPageIndexCache::count_for_document(document_a),
+            2,
+            "count_for_document must see only document A's two entries"
+        );
+        assert_eq!(
+            PdfPageIndexCache::count_for_document(document_b),
+            3,
+            "count_for_document must see only document B's three entries"
+        );
+
+        // The reverse (indices_by_page) map is likewise document-scoped: each (document, index)
+        // pair resolves back to the page handle originally cached against it.
+
+        assert_eq!(
+            PdfPageIndexCache::page_for_index(document_a, 0),
+            Some(a_page_0)
+        );
+        assert_eq!(
+            PdfPageIndexCache::page_for_index(document_a, 1),
+            Some(a_page_1)
+        );
+        assert_eq!(
+            PdfPageIndexCache::page_for_index(document_b, 2),
+            Some(b_page_2)
+        );
+
+        // Remove every synthetic entry this test added, across both documents, so the page entries
+        // it introduced do not linger in the shared cache. `remove_index_for_page` clears both the
+        // forward (`pages_by_index`) and reverse (`indices_by_page`) entries for each page.
+
+        for (document, page) in [
+            (document_a, a_page_0),
+            (document_a, a_page_1),
+            (document_b, b_page_0),
+            (document_b, b_page_1),
+            (document_b, b_page_2),
+        ] {
+            PdfPageIndexCache::remove_index_for_page(document, page);
+        }
+
+        // The page entries are gone for both documents.
+
+        assert_eq!(PdfPageIndexCache::count_for_document(document_a), 0);
+        assert_eq!(PdfPageIndexCache::count_for_document(document_b), 0);
+        assert!(PdfPageIndexCache::page_for_index(document_a, 0).is_none());
+        assert!(PdfPageIndexCache::page_for_index(document_b, 2).is_none());
+    }
+
+    #[test]
+    fn document_scoped_counts_isolate_across_live_documents() -> Result<(), PdfiumError> {
+        // The end-to-end counterpart of the pure-logic pin above, driven through the real pdfium
+        // page APIs. I hold two live documents at once so the shared cache provably contains
+        // entries for both, then confirm that a document-scoped count reports each document's own
+        // entries exactly, while the global length reflects the sum of both. This is the assertion
+        // shape the whole suite now uses, and it is correct no matter what other tests do to the
+        // shared cache under the default multi-threaded `cargo test`.
 
         let pdfium = test_bind_to_pdfium();
 
-        // Document A: create two pages and hold live references to both, so A's two entries
-        // persist in the shared cache for the remainder of this test.
+        // Document A: two pages, both held live.
 
         let mut document_a = pdfium.create_new_pdf()?;
 
@@ -1013,8 +1147,7 @@ mod tests {
         let _a_page_0 = document_a.pages().get(0)?;
         let _a_page_1 = document_a.pages().get(1)?;
 
-        // Document B: create three pages and hold live references to all three, so B contributes
-        // exactly three entries to the shared cache.
+        // Document B: three pages, all held live.
 
         let mut document_b = pdfium.create_new_pdf()?;
 
@@ -1028,33 +1161,37 @@ mod tests {
         let _b_page_1 = document_b.pages().get(1)?;
         let _b_page_2 = document_b.pages().get(2)?;
 
-        // The buggy global assertion: the existing suite would expect the shared cache to hold
-        // only the three pages of the document it just created. It actually holds five (A's two
-        // plus B's three), so this fails on the current commit.
-
-        let cached_len = PdfPageIndexCache::lock().pages_by_index.len();
+        // Document-scoped counts are exact and isolated even though both documents (and possibly
+        // others from concurrent tests) are present in the shared cache at the same time.
 
         assert_eq!(
-            cached_len, 3,
-            "global pages_by_index length is not isolated to document B: \
-             the shared cache still holds document A's entries"
+            PdfPageIndexCache::count_for_document(document_a.handle()),
+            2
+        );
+        assert_eq!(
+            PdfPageIndexCache::count_for_document(document_b.handle()),
+            3
         );
 
         Ok(())
     }
 
+    // This test drives pdfium's FFI from eight threads at once, which is only sound when the
+    // `thread_safe` feature serializes access to the library. It is gated accordingly so that it
+    // neither compiles nor runs without that feature (where the concurrent FFI would be undefined
+    // behaviour).
+    #[cfg(feature = "thread_safe")]
     #[test]
-    #[ignore = "reproduces the real parallel SIGABRT; run in isolation, it aborts the test binary"]
-    fn parallel_global_cache_assertions_abort_the_process() {
-        // This is the real-world trigger that the default multi-threaded `cargo test` hits. Each
-        // thread runs the same global-assertion pattern the existing cache tests use: create a
-        // document, take a live page reference, then assert on the PROCESS-GLOBAL cache length.
-        // Because the cache is shared, the threads observe each other's entries and the global
-        // assertions fail. A failing assertion panics while the temporary lock guard is still
-        // held, poisoning the mutex; the following page drop then re-panics on lock().unwrap()
-        // inside its destructor, and Rust escalates that destructor panic to a non-unwinding
-        // abort of the whole binary (signal 6). It is #[ignore]d so it never aborts the normal
-        // run; invoke it deliberately with `cargo test -- --ignored` to observe the abort.
+    fn parallel_document_scoped_counts_do_not_abort() {
+        // Regression pin for the actual reported symptom: the default multi-threaded `cargo test`
+        // aborting the whole binary. Several threads each create a document, take a live page
+        // reference, then assert on the cache. With the document-scoped `count_for_document`
+        // assertion, every thread sees only its own single entry regardless of what the other
+        // threads are doing, so none of them panics, nothing poisons the shared mutex, and no page
+        // drop re-panics inside a destructor. The old global `pages_by_index.len() == 1` assertion
+        // would instead observe the other threads' entries, panic while holding the lock guard,
+        // poison the mutex, and escalate to a process abort. Every worker thread is joined and
+        // required to have succeeded.
 
         use std::thread;
 
@@ -1073,10 +1210,11 @@ mod tests {
 
                     let _page_ref = document.pages().get(0)?;
 
-                    // The buggy global assertion, made while holding the lock guard exactly as the
-                    // existing suite does, so a failure poisons the mutex.
+                    // Document-scoped assertion: this thread only ever sees its own entry, so it
+                    // is stable under concurrency. The accessor is guard-free, so even a regression
+                    // here could not poison the cache mutex.
 
-                    assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 1);
+                    assert_eq!(PdfPageIndexCache::count_for_document(document.handle()), 1);
 
                     Ok(())
                 })
@@ -1084,7 +1222,85 @@ mod tests {
             .collect();
 
         for handle in handles {
-            let _ = handle.join();
+            handle
+                .join()
+                .expect("worker thread panicked, indicating the cache assertions are not isolated")
+                .expect("worker thread returned a pdfium error");
         }
+    }
+
+    #[test]
+    fn failed_document_scoped_assertion_does_not_poison_the_cache_mutex() {
+        // Proves the failure mode targeted by this fix is gone, without needing pdfium. The
+        // original bug was: a document-scoped assertion evaluated against a value pulled from a
+        // live `MutexGuard` would, on failure, panic while that guard was still held, poison
+        // PAGE_INDEX_CACHE, and then the panicking test's own unwind would drop a live PdfPage
+        // whose destructor re-locks the now-poisoned mutex and double-panics into a process abort.
+        //
+        // Here a deliberately wrong document-scoped assertion is run inside `catch_unwind` using
+        // the guard-free `count_for_document` accessor. Because that accessor releases the lock
+        // before the value is compared, the panic happens with no guard held, so the mutex must NOT
+        // be poisoned: a following `lock()` still succeeds and a following `count_for_document`
+        // still works. That is exactly what keeps a subsequent PdfPage drop safe rather than
+        // abort-inducing.
+
+        use crate::bindgen::{FPDF_DOCUMENT, FPDF_PAGE};
+        use crate::pdf::document::page::PdfPageContentRegenerationStrategy;
+
+        let document = 0xC000_0000usize as FPDF_DOCUMENT;
+        let page_0 = 0xC000_0001usize as FPDF_PAGE;
+        let page_1 = 0xC000_0002usize as FPDF_PAGE;
+
+        for (page, index) in [(page_0, 0), (page_1, 1)] {
+            PdfPageIndexCache::cache_props_for_page(
+                document,
+                page,
+                index,
+                PdfPageContentRegenerationStrategy::AutomaticOnEveryChange,
+            );
+        }
+
+        // Suppress the panic backtrace that the deliberately failing assertion would otherwise
+        // print, so the test output is not misleading, then run the failing assertion in isolation.
+
+        let previous_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            // Deliberately WRONG: the document has two entries, not 999. This models a genuine
+            // future regression in a document-scoped cache assertion.
+            assert_eq!(
+                PdfPageIndexCache::count_for_document(document),
+                999,
+                "deliberately failing document-scoped assertion"
+            );
+        }));
+
+        std::panic::set_hook(previous_hook);
+
+        // The assertion must have failed...
+        assert!(
+            result.is_err(),
+            "the deliberately wrong assertion was expected to panic"
+        );
+
+        // ... but because no MutexGuard was held across that panic, the cache mutex must not be
+        // poisoned. A poisoned mutex is precisely what turned a failed assertion into a process
+        // abort via the re-locking PdfPage destructor.
+        assert!(
+            super::PAGE_INDEX_CACHE.lock().is_ok(),
+            "the cache mutex must not be poisoned by a failed document-scoped assertion"
+        );
+
+        // And the cache is still usable after the failed assertion.
+        assert_eq!(PdfPageIndexCache::count_for_document(document), 2);
+
+        // Clean up this test's synthetic entries.
+
+        for page in [page_0, page_1] {
+            PdfPageIndexCache::remove_index_for_page(document, page);
+        }
+
+        assert_eq!(PdfPageIndexCache::count_for_document(document), 0);
     }
 }

--- a/src/pdf/document/page/index_cache.rs
+++ b/src/pdf/document/page/index_cache.rs
@@ -971,4 +971,120 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn global_cache_assertions_are_not_isolated_across_documents() -> Result<(), PdfiumError> {
+        // This test encodes the buggy global assumption that the existing cache tests rely on:
+        // that the process-global PAGE_INDEX_CACHE holds entries only for the document currently
+        // under test. I set up two live documents at once so that assumption is provably false,
+        // then run the exact global-style length assertion the existing suite uses.
+        //
+        // It is RED on this commit because document A's entries are still present when I assert
+        // that only document B's entries exist. That is the isolation flaw: any test that asserts
+        // on `pages_by_index.len()` or `pages_by_index.is_empty()` is really asserting on state
+        // owned by every other test that happens to be touching the shared cache. Under the
+        // default multi-threaded `cargo test`, a concurrent test supplies that foreign state and
+        // the assertion fails; here I supply it deterministically from a single thread.
+        //
+        // This should turn GREEN once the assertions become document-scoped (counting only the
+        // entries whose document handle matches the document under test), as proposed in the
+        // linked issue.
+        //
+        // I deliberately read the cache length into a local BEFORE asserting, so the temporary
+        // MutexGuard from lock() is released before assert_eq! can panic. That keeps the failure
+        // a clean unwinding assertion the harness reports as FAIL. If I asserted while still
+        // holding the guard, the panic would poison the mutex and the subsequent page drops would
+        // re-panic inside their destructors, aborting the whole test binary (signal 6), which is
+        // exactly the real-world symptom described in the issue.
+
+        let pdfium = test_bind_to_pdfium();
+
+        // Document A: create two pages and hold live references to both, so A's two entries
+        // persist in the shared cache for the remainder of this test.
+
+        let mut document_a = pdfium.create_new_pdf()?;
+
+        for _ in 1..=2 {
+            document_a
+                .pages_mut()
+                .create_page_at_end(PdfPagePaperSize::a4())?;
+        }
+
+        let _a_page_0 = document_a.pages().get(0)?;
+        let _a_page_1 = document_a.pages().get(1)?;
+
+        // Document B: create three pages and hold live references to all three, so B contributes
+        // exactly three entries to the shared cache.
+
+        let mut document_b = pdfium.create_new_pdf()?;
+
+        for _ in 1..=3 {
+            document_b
+                .pages_mut()
+                .create_page_at_end(PdfPagePaperSize::a4())?;
+        }
+
+        let _b_page_0 = document_b.pages().get(0)?;
+        let _b_page_1 = document_b.pages().get(1)?;
+        let _b_page_2 = document_b.pages().get(2)?;
+
+        // The buggy global assertion: the existing suite would expect the shared cache to hold
+        // only the three pages of the document it just created. It actually holds five (A's two
+        // plus B's three), so this fails on the current commit.
+
+        let cached_len = PdfPageIndexCache::lock().pages_by_index.len();
+
+        assert_eq!(
+            cached_len, 3,
+            "global pages_by_index length is not isolated to document B: \
+             the shared cache still holds document A's entries"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[ignore = "reproduces the real parallel SIGABRT; run in isolation, it aborts the test binary"]
+    fn parallel_global_cache_assertions_abort_the_process() {
+        // This is the real-world trigger that the default multi-threaded `cargo test` hits. Each
+        // thread runs the same global-assertion pattern the existing cache tests use: create a
+        // document, take a live page reference, then assert on the PROCESS-GLOBAL cache length.
+        // Because the cache is shared, the threads observe each other's entries and the global
+        // assertions fail. A failing assertion panics while the temporary lock guard is still
+        // held, poisoning the mutex; the following page drop then re-panics on lock().unwrap()
+        // inside its destructor, and Rust escalates that destructor panic to a non-unwinding
+        // abort of the whole binary (signal 6). It is #[ignore]d so it never aborts the normal
+        // run; invoke it deliberately with `cargo test -- --ignored` to observe the abort.
+
+        use std::thread;
+
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                thread::spawn(|| -> Result<(), PdfiumError> {
+                    let pdfium = test_bind_to_pdfium();
+
+                    let mut document = pdfium.create_new_pdf()?;
+
+                    let _page = document
+                        .pages_mut()
+                        .create_page_at_start(PdfPagePaperSize::a4())?;
+
+                    // Take a live reference so this thread contributes an entry to the shared cache.
+
+                    let _page_ref = document.pages().get(0)?;
+
+                    // The buggy global assertion, made while holding the lock guard exactly as the
+                    // existing suite does, so a failure poisons the mutex.
+
+                    assert_eq!(PdfPageIndexCache::lock().pages_by_index.len(), 1);
+
+                    Ok(())
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            let _ = handle.join();
+        }
+    }
 }


### PR DESCRIPTION
Fixes #266.

The page index cache tests assert on the process-global `pages_by_index`, which fails whenever another test holds live pages concurrently... the failed assertion panics while holding the cache mutex, poisons it, and the next `PdfPage` drop turns that into a process abort.

Two things have to be true to end that cascade, so I do both.

First, the assertions have to be document-scoped, so another test's live pages can't move them out from under me. I add three `#[cfg(test)]` accessors next to `get_index_for_page`: `count_for_document`, `maximum_index_for_document`, and `page_for_index`. Every global length, emptiness, and max-index assertion now goes through them.

Second, and this is the part that actually removes the abort, those accessors are guard-free... each one takes the lock internally and returns a plain value, so no test ever holds a `MutexGuard` across an assertion. A failing assertion then panics with no guard live, so it can't poison the cache mutex, so the next `PdfPage` drop can't double-panic into an abort. Scoping alone would only make the assertions pass more often; releasing the guard first is what makes a failure safe.

The tests, all pdfium-free where it counts:

- `count_for_document_isolates_entries_by_document_handle` drives the shared cache with synthetic handles, so it needs no native library. It asserts only on its own document's entries, never on a global snapshot another thread can move.
- `failed_document_scoped_assertion_does_not_poison_the_cache_mutex` is the effectiveness proof. It runs a deliberately wrong document-scoped assertion inside `catch_unwind`, then shows the cache mutex is still un-poisoned and the cache still usable. Before this patch that same shape aborts the process.
- `parallel_document_scoped_counts_do_not_abort` exercises the real concurrent path and is gated behind `thread_safe`, since it needs the library serialized.

I left `lock()` itself untouched, `.unwrap()` and all, as the tripwire it's meant to be. Nothing here recovers from a poisoned mutex... it just makes sure the tests stop poisoning it.

Opening as a draft while you take a look.
