### PR TITLE
Document the matrix render path's /Rotate semantics + render-equivalence tests

### DIFF
--- a/src/pdf/document/page/render_config.rs
+++ b/src/pdf/document/page/render_config.rs
@@ -602,10 +602,19 @@ impl PdfRenderConfig {
         "the [PdfPage] during rendering.",
         "the [PdfPage] during rendering,",
         "Pdfium's rendering pipeline supports _either_ rendering with form data _or_ rendering with
-            a custom transformation matrix, but not both at the same time. Applying any transformation
-            automatically disables rendering of form data. If you must render form data while simultaneously
-            applying transformations, consider using the [PdfPage::flatten()] function to flatten the
-            form elements and form data into the containing page."
+            a custom transformation matrix, but not both at the same time. Applying a transformation via
+            these setters automatically disables rendering of form data, with one exception... `reset_matrix()`
+            replaces the matrix directly and does _not_ disable it, so pair `reset_matrix()` with
+            `render_form_data(false)` when you want the matrix render path. If you must render form data while
+            simultaneously applying transformations, consider using the [PdfPage::flatten()] function to
+            flatten the form elements and form data into the containing page.
+
+            `FPDF_RenderPageBitmapWithMatrix` composes the supplied matrix on top of the page's standard
+            display transform, which already applies the page's intrinsic `/Rotate`, flips y-up PDF points to
+            y-down device pixels, and scales into the destination rect. The matrix therefore operates in
+            display-oriented device space, so a rotated page needs no special caller-side handling, and strip
+            or tile rendering is a device-space matrix `[scale, 0, 0, scale, 0, -y_offset]` combined with
+            `set_fixed_size()`, with no per-`/Rotate` derivation."
     );
 
     // The internal implementation of the transform() function used by the create_transform_setters!() macro.
@@ -1032,8 +1041,9 @@ mod tests {
 
         // First, create a full page render of the target page.
 
-        let full_bitmap =
-            page.render_with_config(&PdfRenderConfig::new().set_fixed_size(target_width, target_height))?;
+        let full_bitmap = page.render_with_config(
+            &PdfRenderConfig::new().set_fixed_size(target_width, target_height),
+        )?;
         let full_bytes = full_bitmap.as_image()?.to_rgba8().into_raw();
         let row_bytes = (target_width as usize) * 4;
 
@@ -1044,7 +1054,8 @@ mod tests {
         let mut stitched: Vec<u8> = Vec::with_capacity(full_bytes.len());
 
         for i in 0..strips {
-            let mut strip_bitmap = PdfBitmap::empty(target_width, strip_height, full_bitmap.format()?)?;
+            let mut strip_bitmap =
+                PdfBitmap::empty(target_width, strip_height, full_bitmap.format()?)?;
 
             page.render_into_bitmap_with_config(
                 &mut strip_bitmap,
@@ -1060,7 +1071,13 @@ mod tests {
 
         // The render output assembled from the strips should exactly match the full page render.
 
-        println!("{}, {}, {}, {}", strip_height, strip_height * strips, target_height, row_bytes);
+        println!(
+            "{}, {}, {}, {}",
+            strip_height,
+            strip_height * strips,
+            target_height,
+            row_bytes
+        );
         assert_eq!(stitched.len(), full_bytes.len());
 
         let mut sums = [0u64; 4]; // Track per-channel mean drift between stitched and full-page renders.
@@ -1142,5 +1159,203 @@ mod tests {
             .create_page_at_start(PdfPagePaperSize::Portrait(PdfPagePaperStandardSize::A4))?;
 
         Ok(config.apply_to_page(&page))
+    }
+
+    /// Per-pixel mean absolute difference across all RGBA channels. Returns
+    /// infinity on a length mismatch so a dimension difference fails an
+    /// equality check and passes a divergence check.
+    fn mean_abs_diff(a: &[u8], b: &[u8]) -> f64 {
+        if a.len() != b.len() {
+            return f64::INFINITY;
+        }
+
+        let sum: u64 = a
+            .iter()
+            .zip(b)
+            .map(|(x, y)| (*x as i64 - *y as i64).unsigned_abs())
+            .sum();
+
+        sum as f64 / a.len() as f64
+    }
+
+    /// Builds a single-page A4 document with two asymmetric filled rectangles,
+    /// so that orientation is observable. A blank page would compare equal under
+    /// any rotation, which is why content is required.
+    fn create_asymmetric_a4(pdfium: &Pdfium) -> Result<PdfDocument<'_>, PdfiumError> {
+        let mut document = pdfium.create_new_pdf()?;
+
+        {
+            let mut page = document
+                .pages_mut()
+                .create_page_at_start(PdfPagePaperSize::Portrait(PdfPagePaperStandardSize::A4))?;
+
+            page.objects_mut().create_path_object_rect(
+                PdfRect::new(
+                    PdfPoints::new(640.0),
+                    PdfPoints::new(60.0),
+                    PdfPoints::new(800.0),
+                    PdfPoints::new(300.0),
+                ),
+                None,
+                None,
+                Some(PdfColor::RED),
+            )?;
+
+            page.objects_mut().create_path_object_rect(
+                PdfRect::new(
+                    PdfPoints::new(40.0),
+                    PdfPoints::new(400.0),
+                    PdfPoints::new(120.0),
+                    PdfPoints::new(560.0),
+                ),
+                None,
+                None,
+                Some(PdfColor::new(0, 0, 255, 255)),
+            )?;
+        }
+
+        Ok(document)
+    }
+
+    /// `FPDF_RenderPageBitmapWithMatrix` composes the caller matrix on top of
+    /// pdfium's display transform, which already applies the page's intrinsic
+    /// `/Rotate`. So the matrix render path with an identity matrix must produce
+    /// byte-identical output to the form-data path, which also applies `/Rotate`,
+    /// for every `/Rotate` value. A caller that mistakenly believed the matrix
+    /// path ignores `/Rotate` and pre-composed a rotation would fail this test.
+    #[test]
+    fn test_matrix_path_matches_form_path_for_each_intrinsic_rotation() -> Result<(), PdfiumError> {
+        let pdfium = test_bind_to_pdfium();
+        let mut document = create_asymmetric_a4(&pdfium)?;
+        let mut page = document.pages_mut().first()?;
+
+        for rotation in [
+            PdfPageRenderRotation::None,
+            PdfPageRenderRotation::Degrees90,
+            PdfPageRenderRotation::Degrees180,
+            PdfPageRenderRotation::Degrees270,
+        ] {
+            page.set_rotation(rotation);
+
+            let width = page.width().value.round() as Pixels;
+            let height = page.height().value.round() as Pixels;
+
+            // Form-data path: applies `/Rotate` automatically.
+            let form = page
+                .render_with_config(&PdfRenderConfig::new().set_target_size(width, height))?
+                .as_image()?
+                .to_rgba8()
+                .into_raw();
+
+            // Matrix path with an identity matrix.
+            let matrix = page
+                .render_with_config(
+                    &PdfRenderConfig::new()
+                        .set_target_size(width, height)
+                        .render_form_data(false),
+                )?
+                .as_image()?
+                .to_rgba8()
+                .into_raw();
+
+            let drift = mean_abs_diff(&matrix, &form);
+            assert!(
+                drift < 1.0,
+                "{rotation:?}: matrix path diverged from the form-data path ({drift:.3}/255), \
+                 so the matrix path is not applying /Rotate the way this test assumes",
+            );
+
+            // Negative control: a half-scale matrix-path render must differ, so a
+            // zero drift above can only mean genuine agreement, not two blanks.
+            let control = page
+                .render_with_config(
+                    &PdfRenderConfig::new()
+                        .set_fixed_size(width, height)
+                        .render_form_data(false)
+                        .scale_page_by_factor(0.5),
+                )?
+                .as_image()?
+                .to_rgba8()
+                .into_raw();
+
+            assert!(
+                mean_abs_diff(&control, &form) > 5.0,
+                "{rotation:?}: negative control did not diverge, the comparison is not discriminating",
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Renders a `/Rotate 90` page as horizontal strips through the matrix path,
+    /// using the device-space strip matrix `[s, 0, 0, s, 0, -y_offset]`, and
+    /// stitches them. The result must match the full form-data render. If a
+    /// caller baked a rotation into the strip matrix, the strips would not stitch
+    /// to the correctly-rotated full render. `reset_matrix()` does not disable
+    /// form data on its own, so `render_form_data(false)` is required.
+    #[test]
+    fn test_matrix_path_strip_stitch_matches_full_render() -> Result<(), PdfiumError> {
+        let pdfium = test_bind_to_pdfium();
+        let mut document = create_asymmetric_a4(&pdfium)?;
+        let mut page = document.pages_mut().first()?;
+        page.set_rotation(PdfPageRenderRotation::Degrees90);
+
+        let width = page.width().value.round() as Pixels;
+        let height = page.height().value.round() as Pixels;
+
+        let full = page
+            .render_with_config(&PdfRenderConfig::new().set_target_size(width, height))?
+            .as_image()?
+            .to_rgba8()
+            .into_raw();
+
+        let strips: Pixels = 5;
+        let mut stitched: Vec<u8> = Vec::with_capacity(full.len());
+        let mut y_offset: Pixels = 0;
+
+        for i in 0..strips {
+            // The last strip absorbs any remainder so the strips cover the page.
+            let strip_height = if i == strips - 1 {
+                height - y_offset
+            } else {
+                height / strips
+            };
+
+            let strip = page
+                .render_with_config(
+                    &PdfRenderConfig::new()
+                        .set_fixed_size(width, strip_height)
+                        .clip(0, 0, width, strip_height)
+                        .render_form_data(false)
+                        .reset_matrix(PdfMatrix::new(
+                            1.0,
+                            0.0,
+                            0.0,
+                            1.0,
+                            0.0,
+                            -(y_offset as f32),
+                        ))?,
+                )?
+                .as_image()?
+                .to_rgba8()
+                .into_raw();
+
+            stitched.extend_from_slice(&strip);
+            y_offset += strip_height;
+        }
+
+        assert_eq!(
+            stitched.len(),
+            full.len(),
+            "stitched strips must cover the full page",
+        );
+
+        let drift = mean_abs_diff(&stitched, &full);
+        assert!(
+            drift < 1.0,
+            "matrix-path strips did not stitch to the full render ({drift:.3}/255)",
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Follows up #253, which documents that the matrix render path already applies the page's intrinsic `/Rotate`. This is the documentation and the render-level tests that pin it.

## What this does

Two things, both in `render_config.rs`, no API change:

- Documents the matrix render path's semantics on the transform setters. `FPDF_RenderPageBitmapWithMatrix` composes the caller matrix on top of the page's display transform, which already applies `/Rotate`, flips y-up PDF points to y-down device pixels, and scales into the target rect. So the caller matrix operates in display-oriented device space, a rotated page needs no special handling, and strip or tile rendering is `[scale, 0, 0, scale, 0, -y_offset]` combined with `set_fixed_size()`.
- Corrects one inaccuracy in that same doc... `reset_matrix()` sets the matrix directly and does not disable form data, unlike `transform()` and the other setters, so it has to be paired with `render_form_data(false)` for the matrix path. The macro doc claimed "any transformation" disables form data, which isn't true for `reset_matrix()`.

## Why

The matrix path's rotation behaviour wasn't documented anywhere, which led a downstream (libviprs) to hand-derive per-`/Rotate` matrices on the belief that the matrix path ignores `/Rotate`. It doesn't, so that double-applied the rotation and transposed rotated pages. The evidence is in #253: `fpdf_view.cpp` builds `transform_matrix = pPage->GetDisplayMatrix(...)` then `transform_matrix *= caller_matrix`, and `thumbnail()` has always rendered rotated pages correctly through the matrix path with an identity matrix.

## Tests

Two render-level tests in the existing `render_config` test module, no new `tests/` directory, both using the existing `test_bind_to_pdfium` harness:

- `test_matrix_path_matches_form_path_for_each_intrinsic_rotation`: the matrix path with an identity matrix equals the form-data path, per pixel, for `/Rotate 0/90/180/270`, with a per-rotation negative control proving the comparison discriminates.
- `test_matrix_path_strip_stitch_matches_full_render`: five strips rendered through the matrix path with `[scale, 0, 0, scale, 0, -y_offset]` stitch back to the full form-data render.

Run them under `--test-threads=1`, like the other render tests here.
